### PR TITLE
Feature/animate mapload

### DIFF
--- a/src/components/BigLoader.js
+++ b/src/components/BigLoader.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from 'styled-components';
+import { PropagateLoader } from 'react-spinners';
+
+const LoaderWrapper = styled.div`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const BigLoader = () => (
+  <LoaderWrapper>
+    <PropagateLoader
+      color={`${config.colors.interaction}`}
+    />
+  </LoaderWrapper>
+);
+
+export default BigLoader;

--- a/src/pages/Reports/components/BaseMap/index.js
+++ b/src/pages/Reports/components/BaseMap/index.js
@@ -1,7 +1,9 @@
-import React, { PureComponent } from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import MapboxGL from 'mapbox-gl';
+
+import BigLoader from '~/components/BigLoader';
 
 const MB_STYLE_URL = `${config.reportsMap.style}?fresh=true`;
 MapboxGL.accessToken = MapboxGL.accessToken || config.map.accessToken;
@@ -20,7 +22,8 @@ class BaseMap extends PureComponent {
 
   static defaultProps = {
     maxBounds: config.reportsMap.maxBounds,
-    onLoad: () => {}
+    onLoad: () => {
+    }
   }
 
   state = {
@@ -36,20 +39,25 @@ class BaseMap extends PureComponent {
     });
 
     this.map.on('load', () => {
-      this.setState({ isLoading: false });
+      this.setState({isLoading: false});
       this.props.onLoad(this.map);
     });
   }
 
   render() {
+    const Loader = this.state.isLoading ? (<BigLoader />) : null;
     return (
       <StyledMap
         className={this.props.className}
-        ref={(ref) => { this.root = ref; }}
+        ref={(ref) => {
+          this.root = ref;
+        }}
       >
+        {Loader}
         {this.props.children}
       </StyledMap>
     );
+
   }
 }
 

--- a/src/pages/Reports/components/OverviewMap/OverviewMap.js
+++ b/src/pages/Reports/components/OverviewMap/OverviewMap.js
@@ -4,7 +4,7 @@
  *  TODO: fetch/mock marker data and pass as prop to WebGl OverviewMap
  */
 
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import withRouter from 'react-router/withRouter';
 import { Route } from 'react-router-dom';
@@ -46,7 +46,8 @@ class OverviewMap extends Component {
 
     this.state = {
       // [lng, lat]
-      mapCenter: null
+      mapCenter: null,
+      isLoading: true
     };
   }
 
@@ -86,8 +87,23 @@ class OverviewMap extends Component {
     this.props.setSelectedReport(null);
   }
 
+  onMapLoad = () => {
+    this.setState({ isLoading: false });
+  }
+
   render() {
     const { reports, selectedReport, match } = this.props;
+
+    const mapControls = (
+      <Fragment>
+        <LocatorControl
+          key="ReportsOverviewMap__LocatorControl"
+          onChange={this.handleLocationChange}
+          customPosition={{ bottom: '42px', right: '7px' }}
+        />
+        <AddButton onTab={this.onAddButtonTab} />
+      </Fragment>
+    );
 
     return (
       <MapView>
@@ -98,14 +114,12 @@ class OverviewMap extends Component {
             center={this.state.mapCenter}
             onMarkerClick={this.handleMarkerClick}
             disabled={match.isExact}
+            onLoad={this.onMapLoad}
           />
 
-          <LocatorControl
-            key="ReportsOverviewMap__LocatorControl"
-            onChange={this.handleLocationChange}
-            customPosition={{ bottom: '42px', right: '7px' }}
-          />
-          <AddButton onTab={this.onAddButtonTab} />
+          {
+            this.state.isLoading ? null : mapControls
+          }
 
         </MapWrapper>
         {selectedReport && (

--- a/src/pages/Reports/components/OverviewMap/WebglMap.js
+++ b/src/pages/Reports/components/OverviewMap/WebglMap.js
@@ -10,12 +10,14 @@ import BaseMap from '~/pages/Reports/components/BaseMap';
 class WebglMap extends PureComponent {
   static propTypes = {
     reportsData: PropTypes.array,
-    center: PropTypes.array
+    center: PropTypes.array,
+    onLoad: PropTypes.func
   }
 
   static defaultProps = {
     reportsData: [],
-    center: null
+    center: null,
+    onLoad: () => {}
   }
 
   nav = new MapboxGL.NavigationControl({ showCompass: false })
@@ -42,6 +44,8 @@ class WebglMap extends PureComponent {
 
     // in order to rerender Report Markers
     this.forceUpdate();
+
+    this.props.onLoad();
   }
 
   toggleZoomControl = (isActive) => {

--- a/src/pages/Reports/components/OverviewMap/WebglMap.js
+++ b/src/pages/Reports/components/OverviewMap/WebglMap.js
@@ -45,6 +45,7 @@ class WebglMap extends PureComponent {
     // in order to rerender Report Markers
     this.forceUpdate();
 
+    // notify containers that map has been initialized
     this.props.onLoad();
   }
 

--- a/src/pages/Reports/components/SubmitReport/LocateMeMap/LocateMeMap.js
+++ b/src/pages/Reports/components/SubmitReport/LocateMeMap/LocateMeMap.js
@@ -76,14 +76,14 @@ const InvalidAdressIndicator = styled(AddressIndicator)`
   color: ${config.colors.error};
 `;
 
-// TODO: when location is pinned: 1. do not allow map drag
 
 class LocateMeMap extends Component {
   constructor(props) {
     super(props);
     this.state = {
       mapHasBeenDragged: false,
-      validationDataLoaded: false
+      validationDataLoaded: false,
+      isLoading: true
     };
   }
 
@@ -136,6 +136,10 @@ class LocateMeMap extends Component {
     this.onMapMove(coordsObj);
   };
 
+  onMapLoad = () => {
+    this.setState({ isLoading: false });
+  }
+
   render() {
     return (
       <MapView>
@@ -149,7 +153,7 @@ class LocateMeMap extends Component {
           )
         }
 
-        {this.props.locationMode === LOCATION_MODE_GEOCODING && (
+        {!this.state.isLoading && this.props.locationMode === LOCATION_MODE_GEOCODING && (
           <Fragment>
             {!this.getPinned() && (
               <SearchBar onSubmit={this.onSearchAddress} />
@@ -162,28 +166,37 @@ class LocateMeMap extends Component {
 
 
         <MapWrapper>
-          {this.props.locationMode && (
-          <StaticMarker
-            pinned={this.getPinned()}
-          />
-          )}
-
-          {this.props.tempLocation && this.props.tempLocation.address && this.props.tempLocation.valid && (
-            <AddressIndicator>{this.props.tempLocation.address}</AddressIndicator>
-          )}
-          {this.props.tempLocation && !this.props.tempLocation.valid && (
-            <InvalidAdressIndicator>{config.reportsLocateMeMap.outofBoundaryText}</InvalidAdressIndicator>
-            )}
-
+          
           <StyledWebGlMap
             center={this.getCenter()}
             className="locate-me-map"
             onMapDrag={this.onMapMove}
             allowDrag={!this.getPinned()}
+            onLoad={this.onMapLoad}
           />
+
+          {
+            !this.state.isLoading && (
+              <Fragment>
+                {this.props.locationMode && (
+                  <StaticMarker
+                    pinned={this.getPinned()}
+                  />
+                )}
+
+                {this.props.tempLocation && this.props.tempLocation.address && this.props.tempLocation.valid && (
+                  <AddressIndicator>{this.props.tempLocation.address}</AddressIndicator>
+                )}
+                {this.props.tempLocation && !this.props.tempLocation.valid && (
+                  <InvalidAdressIndicator>{config.reportsLocateMeMap.outofBoundaryText}</InvalidAdressIndicator>
+                )}
+              </Fragment>
+            )
+          }
+
         </MapWrapper>
 
-        {(this.props.locationMode === LOCATION_MODE_GEOCODING && !this.getPinned()) && (
+        {!this.state.isLoading && (this.props.locationMode === LOCATION_MODE_GEOCODING && !this.getPinned()) && (
         <LocatorControl
           key="ReportsLocateMap__LocatorControl"
           onChange={this.onlocateMeMarkerUse}
@@ -191,7 +204,7 @@ class LocateMeMap extends Component {
         />
         )}
 
-        {!this.getPinned() && (
+        {!this.state.isLoading && !this.getPinned() && (
           <PinLocationButton
             onConfirm={this.props.pinLocation}
             text="Diese Position bestätigen"

--- a/src/pages/Reports/components/SubmitReport/LocateMeMap/WebglMap.js
+++ b/src/pages/Reports/components/SubmitReport/LocateMeMap/WebglMap.js
@@ -11,14 +11,16 @@ class WebglMap extends PureComponent {
     center: PropTypes.arrayOf(PropTypes.number),
     zoom: PropTypes.number,
     onMapDrag: PropTypes.func,
-    allowDrag: PropTypes.bool
+    allowDrag: PropTypes.bool,
+    onLoad: PropTypes.func
   }
 
   static defaultProps = {
     center: config.map.view.center,
     zoom: 18, // TODO: make this configurable
     onMapDrag: () => console.log('onMapDrag says implement me'),
-    allowDrag: true
+    allowDrag: true,
+    onLoad: () => {}
   }
 
   map = null
@@ -66,6 +68,9 @@ class WebglMap extends PureComponent {
 
     this.map.on('dragend', this.handleMoveEnd);
     this.map.on('move', this.handleMove);
+
+    // notify containers that map has been initialized
+    this.props.onLoad();
   }
 
   setView = (view, animate = false) => {

--- a/src/pages/Reports/components/SubmitReport/SubmitReport.js
+++ b/src/pages/Reports/components/SubmitReport/SubmitReport.js
@@ -6,8 +6,7 @@
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
-// eslint-disable-next-line no-unused-vars
-import { PropagateLoader } from 'react-spinners';
+
 import {
   setLocationMode,
   LOCATION_MODE_GEOCODING,
@@ -26,19 +25,12 @@ import BikestandsForm from './BikestandsForm';
 import AdditionalDataForm from './AdditionalDataForm';
 import FormProgressBar from './FormProgressBar';
 import ReportSubmitted from './ReportSubmitted';
+import BigLoader from '~/components/BigLoader';
 
 const SubmitReportWrapper = styled.div`
   min-height: 100%;
   display: flex;
   flex-direction: column;
-`;
-
-const LoaderWrapper = styled.div`
-  width: 100%;
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
 `;
 
 // TODO: dedupe-logic in FormProgressBar Element creation, factor out to function
@@ -119,11 +111,7 @@ class SubmitReport extends PureComponent {
 
     if (submitting) {
       return (
-        <LoaderWrapper>
-          <PropagateLoader
-            color={`${config.colors.interaction}`}
-          />
-        </LoaderWrapper>
+        <BigLoader />
       );
     }
 

--- a/src/styles/Global.js
+++ b/src/styles/Global.js
@@ -89,7 +89,7 @@ export default createGlobalStyle`
     }
     
     .wiggle {
-      animation: shake 0.82s cubic-bezier(.36,.07,.19,.97) both;
+      animation: shake 0.82s cubic-bezier(.36,.07,.19,.97) 0.4s both;
       backface-visibility: hidden;
       perspective: 1000px;
       


### PR DESCRIPTION
# Description

Started with something fun: improving the UX by showing a loader animation while the map loads


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Implementation notes

- The new [`BaseMap`](src/pages/Reports/components/BaseMap/index.js) renders the factored out loader component [`BigLoader`](src/components/BigLoader.js).
- OverViewMap and LocateMeMap are now notified by their respective `WebGlMap` about map initialization and manage an `isLoading` state property to render their controls after the map has been initialized.

# Open question

Shall the loader be used in the other Map (/planungen, /zustand)?

# How Has This Been Tested?

Load each map and inspect that a loader animation is shown until the mapbox map has been loaded. Also notice that custom map controls are not shown during load.

