### PR TITLE
Jest: load dotenv

### DIFF
--- a/jest/jest.config.js
+++ b/jest/jest.config.js
@@ -6,7 +6,6 @@
 const esModules = ['common-tags'];
 
 module.exports = {
-  setupFiles: ['dotenv/config'],
 
   roots: ['<rootDir>/src'],
   testMatch: [

--- a/jest/jest.config.js
+++ b/jest/jest.config.js
@@ -6,6 +6,8 @@
 const esModules = ['common-tags'];
 
 module.exports = {
+  setupFiles: ['dotenv/config'],
+
   roots: ['<rootDir>/src'],
   testMatch: [
     '**/__tests__/**/*.+(ts|tsx|js)',

--- a/jest/jest.config.js
+++ b/jest/jest.config.js
@@ -6,7 +6,6 @@
 const esModules = ['common-tags'];
 
 module.exports = {
-
   roots: ['<rootDir>/src'],
   testMatch: [
     '**/__tests__/**/*.+(ts|tsx|js)',

--- a/jest/jest.setup.js
+++ b/jest/jest.setup.js
@@ -1,0 +1,1 @@
+require('dotenv').config();


### PR DESCRIPTION
# Description

Augments [Jest](https://jestjs.io/)s configuration to load existing environment variables defined in [dotenv](https://github.com/motdotla/dotenv) files (a feature introduced in https://github.com/FixMyBerlin/fixmy.frontend/pull/332)

Required for https://github.com/FixMyBerlin/fixmy.platform/issues/263

# Further explanations

* Because the fix is that small, I don't know if I got the ticket 100% right, but e2e tests are picking up the city setting the same way (see https://github.com/FixMyBerlin/fixmy.platform/issues/263#issuecomment-596129094)
* I noticed another problem while running e2e testss https://github.com/FixMyBerlin/fixmy.platform/issues/292


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

* create file named `.env` in the repository root
* copy content from `./.env.defaults`
* set REGION=bonn`
* in an IDE capable of debugging Jest tests, set a breakpoint in https://github.com/FixMyBerlin/fixmy.frontend/blob/develop/src/config/index.ts#L12
* inspect that `region` evaluates to the value defined early in `.env`
![image](https://user-images.githubusercontent.com/12786207/76151302-d9efb800-60b3-11ea-9ed1-b020be82a9c7.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes