### PR TITLE
Make reports test region-specific

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -121,17 +121,21 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
 // mock a geo location request
 // https://github.com/cypress-io/cypress/issues/2671#issuecomment-564796821
 // MIT License per https://github.com/cypress-io/cypress/blob/develop/LICENSE
-Cypress.Commands.add(
-  'mockGeolocation',
-  (latitude = 52.490064, longitude = 13.38694) => {
-    return cy.window().then(($window) => {
-      return cy.stub(
-        $window.navigator.geolocation,
-        'getCurrentPosition',
-        (callback) => {
-          return callback({ coords: { latitude, longitude } });
-        }
-      );
-    });
-  }
-);
+Cypress.Commands.add('mockGeolocation', (coordinates) => {
+  const coords =
+    coordinates != null
+      ? coordinates
+      : {
+          latitude: 52.490064,
+          longitude: 13.38694
+        };
+  return cy.window().then(($window) => {
+    return cy.stub(
+      $window.navigator.geolocation,
+      'getCurrentPosition',
+      (callback) => {
+        return callback({ coords });
+      }
+    );
+  });
+});

--- a/src/pages/Reports/config/aachen.js
+++ b/src/pages/Reports/config/aachen.js
@@ -29,6 +29,13 @@ export default {
   },
   form: { newsletter: false, zoomOutForInvalidLocations: false },
   title: 'Radbügel für Aachen',
+  tests: {
+    addressInput: 'kasino',
+    mockGeoLocation: {
+      latitude: 50.79,
+      longitude: 6.114
+    }
+  },
   region: 'Aachen',
   intro:
     'Damit du dein Fahrrad überall sicher abschließen kannst, installiert die Stadt Aachen neue Fahrradbügel. Da du als Bürger:in am besten weißt, wo du dein Fahrrad abstellst, kannst du hier melden, wo genau du neue Bügel benötigst.',

--- a/src/pages/Reports/config/berlin.js
+++ b/src/pages/Reports/config/berlin.js
@@ -31,6 +31,13 @@ export default {
   },
   form: { placementNotice: true },
   reportsDisabled: true,
+  tests: {
+    addressInput: 'meh',
+    mockGeoLocation: {
+      latitude: 52.490064,
+      longitude: 13.38694
+    }
+  },
   title:
     'Fahrradbügel für Friedrichshain-Kreuzberg (Status: In Bearbeitung durch den Bezirk)',
   region: 'Friedrichshain-Kreuzberg',

--- a/src/pages/Reports/tests/form.e2e.test.js
+++ b/src/pages/Reports/tests/form.e2e.test.js
@@ -25,7 +25,7 @@ describe('The reports submission form', () => {
         cyElem('reports-locatemode-currentPosition').should('be.visible');
       });
       it('redirects to the map', () => {
-        cy.mockGeolocation();
+        cy.mockGeolocation(config.reports.tests.mockGeoLocation);
         cyElem('reports-locatemode-currentPosition').click();
         cy.window().then((win) => {
           expect(win.navigator.geolocation.getCurrentPosition).to.be.called;
@@ -80,7 +80,7 @@ describe('The reports submission form', () => {
 
     describe('when an address is entered', () => {
       beforeEach(() => {
-        cyElem('map-address-input').type('meh');
+        cyElem('map-address-input').type(config.reports.tests.addressInput);
       });
       it('shows a list of suggestions', () => {
         cyElem('map-address-suggestion')
@@ -119,7 +119,7 @@ describe('The reports submission form', () => {
   describe('the locate me page', () => {
     before(() => {
       cy.visit(config.routes.reports.new);
-      cy.mockGeolocation();
+      cy.mockGeolocation(config.reports.tests.mockGeoLocation);
       cyElem('reports-locatemode-currentPosition').click();
     });
 
@@ -137,7 +137,7 @@ describe('The reports submission form', () => {
     describe('which opens a confirmation dialogue', () => {
       beforeEach(() => {
         cy.visit(config.routes.reports.new);
-        cy.mockGeolocation();
+        cy.mockGeolocation(config.reports.tests.mockGeoLocation);
         cyElem('reports-locatemode-currentPosition').click();
         cyElem('reports-form-confirm-location-button').click();
       });
@@ -238,6 +238,9 @@ describe('The reports submission form', () => {
       cyElem('reports-locker-accept').click();
       cyElem('reports-locker-continue').click();
 
+      // the request body is not region-specific because it is
+      // sourced from a test fixture that contains data
+      // for Mehringdamm in Berlin.
       cy.wait('@postReport')
         .its('request.body')
         .should('deep.equal', {


### PR DESCRIPTION
Integration tests were failing because they contained hardcoded references to locations in Berlin. This PR makes these configurable and adds suitable configurations for Aachen.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
