### PR TITLE
Skip location mode chooser screen on desktop decices

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -3,5 +3,6 @@
   "baseUrl": "http://localhost:8080",
   "//": "not only look for tests in cypress/integration, search everywhere in ./src",
   "integrationFolder": "./src",
-  "testFiles": "**/*.e2e.test.js"
+  "testFiles": "**/*.e2e.test.js",
+  "requestTimeout": 10000
 }

--- a/src/pages/Reports/pages/Landing/TopSection.tsx
+++ b/src/pages/Reports/pages/Landing/TopSection.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import styled from 'styled-components';
 
 import config from '~/pages/Reports/config';
+import { actions } from '~/pages/Reports/state/SubmitReportState';
+import FixMyLogo from '~/images/logofmb@2x.png';
+import MenuButton from '~/components/MenuButton';
+import BycicleParkingBgImg from '~/images/reports/bycicle-parking@3x.png';
+import BycicleParkingBgImgLargeScreen from '~/images/reports/landing-christin-hume-595752-unsplash.jpg';
 import Link from '~/components/Link';
 import MenuButton from '~/pages/Reports/components/MenuButton';
 import ScrollLink from '~/pages/Reports/components/ScrollLink';
@@ -82,7 +89,7 @@ const StyledButton = styled.div`
   text-decoration: none;
   color: ${config.colors.white};
   font-family: '${config.baseFont}', sans-serif;
-  font-size: 14px;
+  font-size: 18px;
   cursor: pointer;
   text-align: center;
   width: 200px;
@@ -101,7 +108,6 @@ const StyledButton = styled.div`
 
 const StyledLink = styled(Link)`
   color: white;
-  font-size: 18px;
 
   &:visited,
   &:hover {
@@ -133,7 +139,45 @@ const CenterLogo = styled.img`
   `};
 `;
 
-const TopSection = ({ toUrl }) => (
+const OnlyDesktop = styled.span`
+  display: none;
+  ${media.l`
+    display: inline;
+  `}
+`;
+
+const OnlyMobile = styled.span`
+  ${media.l`
+    display: none;
+  `}
+`;
+
+const navigateToMap = (dispatch, history) => {
+  dispatch(actions.setLocationModeGeocoding());
+  history.push(config.routes.reports.new);
+};
+
+const ModeChooserLink = () => (
+  <StyledButton className="wiggle" data-cy="reports-landing-cta">
+    <StyledLink to={config.routes.reports.new}>
+      <strong>Sagen Sie uns wo</strong>
+      <br /> in 30 Sekunden
+    </StyledLink>
+  </StyledButton>
+);
+
+const MapButton = ({ onClick }) => (
+  <StyledButton
+    className="wiggle"
+    data-cy="reports-landing-cta"
+    onClick={onClick}
+  >
+    <strong>Sagen Sie uns wo</strong>
+    <br /> in 30 Sekunden
+  </StyledButton>
+);
+
+const TopSection = ({ dispatch, history }) => (
   <Section>
     <MenuButton whiteFill="true" />
     <FlexWrapper>
@@ -148,15 +192,15 @@ const TopSection = ({ toUrl }) => (
       <StyledHeading data-cy="reports-landing-header">
         {config.reports.landing?.title}
       </StyledHeading>
-      <StyledButton className="wiggle" data-cy="reports-landing-cta">
-        <StyledLink to={toUrl}>
-          <strong>Sagen Sie uns wo</strong>
-          <br /> in 30 Sekunden
-        </StyledLink>
-      </StyledButton>
+      <OnlyMobile>
+        <ModeChooserLink />
+      </OnlyMobile>
+      <OnlyDesktop>
+        <MapButton onClick={() => navigateToMap(dispatch, history)} />
+      </OnlyDesktop>
     </FlexWrapper>
     <ScrollLink />
   </Section>
 );
 
-export default TopSection;
+export default connect()(withRouter(TopSection));

--- a/src/pages/Reports/pages/Landing/TopSection.tsx
+++ b/src/pages/Reports/pages/Landing/TopSection.tsx
@@ -5,10 +5,6 @@ import styled from 'styled-components';
 
 import config from '~/pages/Reports/config';
 import { actions } from '~/pages/Reports/state/SubmitReportState';
-import FixMyLogo from '~/images/logofmb@2x.png';
-import MenuButton from '~/components/MenuButton';
-import BycicleParkingBgImg from '~/images/reports/bycicle-parking@3x.png';
-import BycicleParkingBgImgLargeScreen from '~/images/reports/landing-christin-hume-595752-unsplash.jpg';
 import Link from '~/components/Link';
 import MenuButton from '~/pages/Reports/components/MenuButton';
 import ScrollLink from '~/pages/Reports/components/ScrollLink';
@@ -124,7 +120,7 @@ const TopLogo = styled.img`
   ${media.m`
     top: 2em;
     right: 2em;
-    width: 120px;
+    width: 148px;
   `}
 `;
 
@@ -133,7 +129,7 @@ const CenterLogo = styled.img`
 
   ${media.m`
     display: block;
-    width: 5em;
+    width: 80px;
     position: absolute;
     top: 2em;
   `};
@@ -203,4 +199,4 @@ const TopSection = ({ dispatch, history }) => (
   </Section>
 );
 
-export default connect()(withRouter(TopSection));
+export default withRouter(connect()(TopSection));

--- a/src/pages/Reports/pages/Landing/aachen.js
+++ b/src/pages/Reports/pages/Landing/aachen.js
@@ -12,6 +12,7 @@ import FahrRadLogo from '~/images/aachen/fahr-rad-logo@2x.png';
 
 const BottomLogo = styled.img`
   margin: 5em auto 3em;
+  width: 192px;
   ${media.m`
     display: none;
   `};

--- a/src/pages/Reports/pages/Landing/index.tsx
+++ b/src/pages/Reports/pages/Landing/index.tsx
@@ -26,7 +26,7 @@ const RegionalLandingContent = () => {
 
 const Landing = () => (
   <>
-    <TopSection toUrl={`${config.routes.reports.new}`} />
+    <TopSection />
     <ContentWrapper>
       <RegionalLandingContent />
     </ContentWrapper>

--- a/src/pages/Reports/tests/form.e2e.test.js
+++ b/src/pages/Reports/tests/form.e2e.test.js
@@ -177,7 +177,8 @@ describe('The reports submission form', () => {
 
     it('has a title and description', () => {
       cy.get('h3').contains('Bitte entweder noch ein Foto von dem Ort');
-      cy.get('p').contains('Ein Foto des Ortes hilft');
+      if (config.reports.form.placementNotice)
+        cy.get('p').contains('Ein Foto des Ortes hilft');
     });
     it('initially prevents continuing in the form', () => {
       cyElem('reports-additional-continue').should('be.disabled');

--- a/src/pages/Reports/tests/map.e2e.test.js
+++ b/src/pages/Reports/tests/map.e2e.test.js
@@ -60,7 +60,7 @@ describe('The reports map', () => {
 
   describe('the details panel', () => {
     it('has a header with address and report id', () => {
-      cyElem('map-details-header-title').contains(/.+\w\d{1,3}/);
+      cyElem('map-details-header-title').contains(/\S+/);
       cyElem('map-details-header-subtitle').contains(/Meldung\s\d{1,3}/);
     });
     it('has a title, status and description', () => {


### PR DESCRIPTION
Skip the location mode chooser when on a Desktop device

Fixes https://github.com/FixMyBerlin/fixmy.platform/issues/313

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality
  to not work as expected)

## How Has This Been Tested?

Variation 1

- Visit the landing page with a desktop device
- Click the CTA button
- You are taken to the map

Variation 2

- resize the browser window to be the size of a mobile device
- repeat above steps
- you can choose between geolocation and address input

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
