### PR TITLE
Parametrize netlify API redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Each branch gets automatically deployed on netlify:
 - https://fixmyberlin-app.netlify.com/ [master]
 - https://develop--fixmyberlin-app.netlify.com/ [develop]
 
+### Build environment variables
+
+- `NF_API_URL` Configures API proxying through `/api/v1/`. Trailing backslash required.
+- `NF_API_HOST` Configures the host header sent for proxied API requests.
+
 ### Embed Mode
 
 You can test the embed mode by adding a query parameter to the url: `http://localhost:8080/planungen?embed=1`.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,41 +1,11 @@
 [[redirects]]
     from = "/api/v1/*"
-    to = "https://api.fixmyberlin.de/api/:splat"
+    to = "API_URL:splat"
     status = 200
     force = true
     [redirects.headers]
         X-From = "Netlify"
-        X-Forwarded-Host = "fixmyberlin.de"
-        X-Forwarded-Proto = "https"
-
-[[redirects]]
-    from = "/api/next/*"
-    to = "https://fixmyplatform-develop.herokuapp.com/api/:splat"
-    status = 200
-    force = true
-    [redirects.headers]
-        X-From = "Netlify"
-        X-Forwarded-Host = "fixmyberlin-staging.netlify.com"
-        X-Forwarded-Proto = "https"
-
-[[redirects]]
-    from = "/api/aachen/v1/*"
-    to = "https://fixmyaachen.herokuapp.com/api/:splat"
-    status = 200
-    force = true
-    [redirects.headers]
-        X-From = "Netlify"
-        X-Forwarded-Host = "fixmyaachen.netlify.com"
-        X-Forwarded-Proto = "https"
-
-[[redirects]]
-    from = "/api/aachen/next/*"
-    to = "https://fixmyaachen-staging.herokuapp.com/api/:splat"
-    status = 200
-    force = true
-    [redirects.headers]
-        X-From = "Netlify"
-        X-Forwarded-Host = "fixmyaachen-staging.netlify.com"
+        X-Forwarded-Host = "API_HOST"
         X-Forwarded-Proto = "https"
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,11 @@
 [[redirects]]
     from = "/api/v1/*"
-    to = "API_URL:splat"
+    to = "NF_API_URL:splat"
     status = 200
     force = true
     [redirects.headers]
         X-From = "Netlify"
-        X-Forwarded-Host = "API_HOST"
+        X-Forwarded-Host = "NF_API_HOST"
         X-Forwarded-Proto = "https"
 
 [[redirects]]

--- a/src/config/aachen/index.ts
+++ b/src/config/aachen/index.ts
@@ -7,8 +7,8 @@ import defaultColors from '~/config/default/colors';
 
 const apiEndpoints = {
   local: 'http://localhost:8000/api',
-  staging: 'https://fixmyaachen-staging.netlify.com/api/aachen/next',
-  production: 'https://fixmyaachen.netlify.com/api/aachen/v1'
+  staging: 'https://fixmyaachen-staging.netlify.com/api/v1',
+  production: 'https://fixmyaachen.netlify.com/api/v1'
 };
 
 export default {

--- a/src/config/default/base.ts
+++ b/src/config/default/base.ts
@@ -1,6 +1,6 @@
 const apiEndpoints = {
   local: 'http://localhost:8000/api',
-  staging: 'https://fixmyberlin-staging.netlify.com/api/next',
+  staging: 'https://fixmyberlin-staging.netlify.com/api/v1',
   production: 'https://fixmyberlin.de/api/v1'
 };
 


### PR DESCRIPTION
Route all API requests through `/api/v1` instead of region-specific endpoints.

Fixes #https://github.com/FixMyBerlin/fixmy.platform/issues/318

**Does not work yet** requests are failing

## Type of change

Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality
  to not work as expected)
- This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
