### PR TITLE
Change check of data loading state

### DIFF
--- a/src/pages/Reports/pages/OverviewMap/components/ClusteredMarkers/marker-utils.js
+++ b/src/pages/Reports/pages/OverviewMap/components/ClusteredMarkers/marker-utils.js
@@ -60,7 +60,7 @@ function createPinMarker({ markerData, geometry, lngLat, onClick }) {
 
 function setupClusters(name, map, data, radius, handleUpdate) {
   map.on('data', (e) => {
-    if (e.sourceId !== name || !e.isSourceLoaded) return;
+    if (e.sourceId !== name || !map.isSourceLoaded(name)) return;
 
     map.on('move', () => handleUpdate());
     map.on('moveend', () => handleUpdate());


### PR DESCRIPTION
The property `isSourceLoaded` does not
always return the same value as the function `map.isSourceLoaded`.
Using the former value introduces a bug where markers are sometimes not
loaded.

Fixes https://github.com/FixMyBerlin/fixmy.platform/issues/325

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Load a report deep link in Safari, where the error seems to occur most often on my system. Before this fix, marker images would sometimes not appear. Now, they seem to always appear.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
