### PR TITLE
Add view that only shows popup bike lanes

### DIFF
--- a/src/config/default/routes.ts
+++ b/src/config/default/routes.ts
@@ -23,6 +23,7 @@ export default {
     iframe: `${katasterPath}/iFrame-test`,
     email: `${katasterPath}/email`
   },
+  popupbikelanes: '/popupbikelanes',
   signup: '/registrieren',
   login: '/anmelden',
   forgotPassword: '/passwort-vergessen',

--- a/src/pages/Map/components/ProjectMarkers.js
+++ b/src/pages/Map/components/ProjectMarkers.js
@@ -42,6 +42,40 @@ class ProjectMarkers extends PureComponent {
     this.markers = [];
   };
 
+  shouldMarkerBeVisible = (marker) => {
+    if (!Markers[marker.phase]) {
+      return false;
+    }
+
+    const TEMPORARY_PLANNINGS_PHASE_INDEX = 4;
+    const phaseIndex = phasesOrder.indexOf(marker.phase);
+
+    if (this.props.onlyPopupbikelanes) {
+      if (marker.phase !== 'inactive') return false;
+    } else {
+      // Don't show markers whose phase is not active in filterPlannings
+      if (
+        !this.props.filterPlannings[phaseIndex] &&
+        phaseIndex !== TEMPORARY_PLANNINGS_PHASE_INDEX
+      ) {
+        return false;
+      }
+
+      // Don't show temporary plannings if ready phase is disabled
+      if (
+        !this.props.filterPlannings[3] &&
+        phaseIndex === TEMPORARY_PLANNINGS_PHASE_INDEX
+      )
+        return false;
+    }
+
+    if (marker.center == null) {
+      logger(`Marker center missing in project #${marker.id}`);
+      return false;
+    }
+    return true;
+  };
+
   updateMarkers = () => {
     const { active, data, map } = this.props;
     if (!data || !map) {
@@ -55,32 +89,7 @@ class ProjectMarkers extends PureComponent {
     }
 
     this.markers = data.map((marker) => {
-      if (!Markers[marker.phase]) {
-        return null;
-      }
-
-      const TEMPORARY_PLANNINGS_PHASE_INDEX = 4;
-      const phaseIndex = phasesOrder.indexOf(marker.phase);
-
-      // Don't show markers whose phase is not active in filterPlannings
-      if (
-        !this.props.filterPlannings[phaseIndex] &&
-        phaseIndex !== TEMPORARY_PLANNINGS_PHASE_INDEX
-      ) {
-        return null;
-      }
-
-      // Don't show temporary plannings if ready phase is disabled
-      if (
-        !this.props.filterPlannings[3] &&
-        phaseIndex === TEMPORARY_PLANNINGS_PHASE_INDEX
-      )
-        return null;
-
-      if (marker.center == null) {
-        logger(`Marker center missing in project #${marker.id}`);
-        return null;
-      }
+      if (!this.shouldMarkerBeVisible(marker)) return null;
 
       const center = marker.center.coordinates;
       const el = document.createElement('div');

--- a/src/pages/Map/index.js
+++ b/src/pages/Map/index.js
@@ -125,8 +125,20 @@ class MapViewComponent extends PureComponent {
               />
             )}
           />
+          <Route
+            exact
+            path="/popupbikelanes/:id/:name?"
+            render={(props) => (
+              <ProjectDetail
+                apiEndpoint="projects"
+                onCloseRoute="/popupbikelanes"
+                activeView={this.props.activeLayer}
+                token={this.props.token}
+                match={props.match}
+              />
+            )}
+          />
         </MapWrapper>
-        {isEmbedMode && <FMBCredits />}
       </MapView>
     );
   }

--- a/src/pages/Map/map-utils.js
+++ b/src/pages/Map/map-utils.js
@@ -105,6 +105,19 @@ export function setPlanningLegendFilter(map, selected) {
 }
 
 /**
+ * Show all popup bike lanes from the projects layer
+ *
+ * @param {MapboxGL instance} map
+ */
+export function setPopupLanesFilter(map) {
+  const filter = ['==', 'inactive', ['get', 'phase']];
+  map.setFilter(config.map.layers.projects.center, filter);
+  map.setFilter(config.map.layers.projects.overlayLine, filter);
+  map.setFilter(config.map.layers.projects.side0, ['all', sideFilter0, filter]);
+  map.setFilter(config.map.layers.projects.side1, ['all', sideFilter1, filter]);
+}
+
+/**
  * Return a Mapbox expression to access the HBI values embedded in Mapbox
  *
  * @param {*} sideKey which side's HBI value to retrieve (layer prefix)

--- a/src/routes.js
+++ b/src/routes.js
@@ -57,6 +57,10 @@ const Routes = ({ token }) => (
       <Route path={config.routes.projects} component={MapView} />
     )}
 
+    {config.routes.popupbikelanes != null && (
+      <Route path={config.routes.popupbikelanes} component={MapView} />
+    )}
+
     {/* reports page */}
     {config.routes.reports != null && (
       <Route path={`${config.routes.reports.index}`} component={Reports} />


### PR DESCRIPTION
Add a view with a map that only shows corona popup bike lanes

Closes https://github.com/FixMyBerlin/fixmy.platform/issues/332

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Visit the new map at /popupbikelanes
- Visit a temp bike lane's detail page from a direct link
- Visit the old map and try filter options

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
