### PR TITLE
Parse German locale meter input

### DIFF
--- a/src/components2/LocationPicker/LocationPicker.tsx
+++ b/src/components2/LocationPicker/LocationPicker.tsx
@@ -90,7 +90,7 @@ const LocationPicker = ({ onSelect }) => {
         .setLngLat(selected.location)
         .addTo(map)
     );
-    map.flyTo({ center: selected.location, zoom: 16 });
+    map.flyTo({ center: selected.location, zoom: 17 });
   }, [selected, map]);
 
   /**

--- a/src/pages/Gastro/components/SignupForm/index.tsx
+++ b/src/pages/Gastro/components/SignupForm/index.tsx
@@ -17,6 +17,7 @@ import config from '~/pages/Gastro/config';
 import { GastroSignup } from '~/pages/Gastro/types';
 import api from '~/pages/Gastro/api';
 import validate from './validate';
+import parseLength from './parseLength';
 
 /* eslint-disable camelcase */
 export interface FormData {
@@ -27,7 +28,7 @@ export interface FormData {
   email?: string;
   address?: string;
   location?: [number, number];
-  shopfront_length?: number | '';
+  shopfront_length?: string;
   opening_hours?: string;
   tos_accepted?: boolean | '';
 }
@@ -77,7 +78,7 @@ const SignupForm = ({ onSuccess, onSubmit }) => (
           type: 'Point',
           coordinates: values.location
         },
-        shopfront_length: Math.round((values.shopfront_length as number) * 100),
+        shopfront_length: parseLength(values.shopfront_length),
         opening_hours: 'weekend',
         campaign: config.gastro.campaign
       };
@@ -178,8 +179,9 @@ const SignupForm = ({ onSuccess, onSubmit }) => (
           </p>
           <Field
             name="shopfront_length"
-            type="number"
-            step="any"
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]+(,[0-9]+)?"
             component={TextField}
             label="Angabe in Metern z.B. 4,8"
             fullWidth

--- a/src/pages/Gastro/components/SignupForm/parseLength.ts
+++ b/src/pages/Gastro/components/SignupForm/parseLength.ts
@@ -1,0 +1,14 @@
+const replaceDecimal = (value: string) => value.replace(',', '.');
+
+/**
+ * Parse an input floating point or integer formatted as German locale meters
+ * and return the value in centimeters as an integer
+ *
+ * @param value input value from text field
+ */
+const parseLength = (value: string) => {
+  const valueAsFloat = parseFloat(replaceDecimal(value));
+  return Math.round(valueAsFloat * 100.0);
+};
+
+export default parseLength;

--- a/src/pages/Gastro/components/SignupForm/validate.ts
+++ b/src/pages/Gastro/components/SignupForm/validate.ts
@@ -2,6 +2,7 @@
 
 import { FormData } from '.';
 import logger from '~/utils/logger';
+import parseLength from './parseLength';
 
 const validate = (values: FormData) => {
   const errors: {
@@ -32,7 +33,7 @@ const validate = (values: FormData) => {
   }
 
   try {
-    const val = Math.round(100 * (values.shopfront_length as number));
+    const val = parseLength(values.shopfront_length);
     if (val < 0 || val > 5000)
       errors.shopfront_length =
         'Bitte geben Sie die Länge der Ladenfront in Metern an';
@@ -51,7 +52,7 @@ const validate = (values: FormData) => {
     errors.tos_accepted =
       'Bitte stimmen Sie diesen Bedingungen zu, damit wir Ihre Interessensbekundung entgegennehmen können.';
   }
-  logger(errors);
+  logger('Validation', errors, values);
   return errors;
 };
 


### PR DESCRIPTION
Fix html input field with type number not accepting floating point input on Android Chrome even with `step="any"`