### PR TITLE
feat: [WIP] extend duration of BigLoader visibility until reports hav…

### DIFF
--- a/src/components/BigLoader.js
+++ b/src/components/BigLoader.js
@@ -1,20 +1,44 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropagateLoader from 'react-spinners/PropagateLoader';
+import PropTypes from 'prop-types';
 import config from '~/config';
 
-const LoaderWrapper = styled.div`
-  width: 100%;
-  height: 100vh;
+const BaseWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
 `;
 
-const BigLoader = () => (
-  <LoaderWrapper>
-    <PropagateLoader color={`${config.colors.interaction}`} />
-  </LoaderWrapper>
-);
+const WrapperStatic = styled(BaseWrapper)`
+  width: 100%;
+  height: 100vh;
+`;
+
+const WrapperAbsolute = styled(BaseWrapper)`
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+`;
+
+const BigLoader = ({ useAbsolutePositioning }) => {
+  const Wrapper = useAbsolutePositioning ? WrapperAbsolute : WrapperStatic;
+  return (
+    <Wrapper>
+      <PropagateLoader color={`${config.colors.interaction}`} />
+    </Wrapper>
+  );
+};
+
+BigLoader.propTypes = {
+  useAbsolutePositioning: PropTypes.bool
+};
+
+BigLoader.defaultProps = {
+  useAbsolutePositioning: false
+};
 
 export default BigLoader;

--- a/src/pages/Reports/components/BaseMap/index.js
+++ b/src/pages/Reports/components/BaseMap/index.js
@@ -44,18 +44,31 @@ class BaseMap extends PureComponent {
   }
 
   render() {
-    const Loader = this.state.isLoading ? <BigLoader /> : null;
+    // While the map initializes, show loading animation.
+    // If configured (by setting isReportsDataLoaded to a boolean),
+    // also show loader until the prop value toggles.
+    const isOverlayLoaded = this.props.didOverlayLoad;
+    const isOverlayLoadTogglePropused = isOverlayLoaded !== undefined;
+    const isMapInitializing = this.state.isLoading;
+    const isMapInitializingOrOverlayLoading =
+      isMapInitializing || !isOverlayLoaded;
+    const isLoaderShown = isOverlayLoadTogglePropused
+      ? isMapInitializingOrOverlayLoading
+      : isMapInitializing;
+
     return (
-      <StyledMap
-        className={this.props.className}
-        ref={(ref) => {
-          this.root = ref;
-        }}
-        data-cy="reports-basemap"
-      >
-        {Loader}
-        {this.props.children}
-      </StyledMap>
+      <>
+        {isLoaderShown && <BigLoader useAbsolutePositioning />}
+        <StyledMap
+          className={this.props.className}
+          ref={(ref) => {
+            this.root = ref;
+          }}
+          data-cy="reports-basemap"
+        >
+          {this.props.children}
+        </StyledMap>
+      </>
     );
   }
 }
@@ -65,7 +78,10 @@ BaseMap.propTypes = {
   onLoad: PropTypes.func,
   onMove: PropTypes.func,
   className: PropTypes.string,
-  children: PropTypes.node
+  children: PropTypes.node,
+  // purposely allowing didOverlayLoad to be undefined
+  // eslint-disable-next-line react/require-default-props
+  didOverlayLoad: PropTypes.bool
 };
 
 BaseMap.defaultProps = {

--- a/src/pages/Reports/pages/OverviewMap/components/WebglMap.js
+++ b/src/pages/Reports/pages/OverviewMap/components/WebglMap.js
@@ -94,12 +94,14 @@ class WebglMap extends PureComponent {
   render() {
     const { reportsData, onMarkerClick, selectedReport, detailId } = this.props;
 
+    const isReportsDataLoaded = !!reportsData.length;
     return (
       <BaseMap
         onLoad={(map) => this.onLoad(map)}
         onMove={() => this.props.onMove()}
+        didOverlayLoad={isReportsDataLoaded}
       >
-        {reportsData.length > 0 && (
+        {isReportsDataLoaded > 0 && (
           <ClusteredMarkers
             data={toGeojson(reportsData)}
             map={this.map}


### PR DESCRIPTION
…e been fetched

Fixes https://github.com/FixMyBerlin/fixmy.platform/issues/399

## Type of change

- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

* visit the Reports OverviewMap (/meldungen/radbuegel/friedrichshain-kreuzberg/karte). A loading indicator should be shown right until the map gets visible and already shows reports. → Condition for visibility has been extended.
* visit the overviewMap (http://localhost:8080/meldungen/radbuegel/friedrichshain-kreuzberg/neu/1). A loading indicator is shown until the map has initialized → Maps Re-Using the BaseMap still works.

