### PR TITLE
Chore/cypress setup deprecation

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -61,12 +61,13 @@ module.exports = (on, config) => {
 
   // modify the way browsers are launched,
   // see https://docs.cypress.io/api/plugins/browser-launch-api.html#Usage
-  on('before:browser:launch', (browser = {}, args) => {
+  on('before:browser:launch', (browser = {}, launchOptions) => {
     if (browser.name === 'chrome') {
+      const { args } = launchOptions;
       setAutoDevTools(args);
       setWindowPos(args);
     }
-    return args;
+    return launchOptions;
   });
 
   on('file:preprocessor', wp({ webpackOptions }));

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-use-before-define */
 require('dotenv').config();
 const wp = require('@cypress/webpack-preprocessor');
 
@@ -5,55 +6,6 @@ const log = require('debug')('cypress:plugins');
 
 const baseConfig = require('../../cypress.json');
 const webpackOptions = require('../../webpack/webpack.config.dev.js');
-
-// immediately open dev tools so we can inspect breakpoint halts
-// (when we added a "debugger" statement in our code
-const setAutoDevTools = (args) => args.push('--auto-open-devtools-for-tabs');
-
-// Set Chrome's window position and size
-//
-// Use an environment variable to control where the Chrome browser window will
-// be opened by Cypress. As an example:
-//
-//   CYPRESS_BROWSER_WINDOW="1920,1080;1920,0" npm run test:e2e-chrome
-//
-// would run cypress tests with a window of size 1920x1080 with its upper left
-// corner at 1920,0 on the monitor.
-const setWindowPos = (args) => {
-  const { cypressBrowserWindow } = process.env;
-  if (cypressBrowserWindow == null) return;
-
-  const [windowSize, windowPosition] = cypressBrowserWindow.split(';');
-  args.push(
-    '--user-data-dir="~/chrome-test-user"',
-    `--window-size=${windowSize}`,
-    `--window-position=${windowPosition}`
-  );
-};
-
-/**
- * Generate an array of pattern for selecting tests to run
- *
- * Expects an environment variable `REGION` with a corresponding entry
- * in `cypress.json` under the key `whitelist`, containing an array of
- * path segments to match for.
- *
- * @returns string[] A list of file patterns
- */
-const getPatternsForRegion = () => {
-  const makePattern = (page) => `**/${page}/**/*.e2e.test.js`;
-
-  const region = process.env.REGION;
-  const whitelist =
-    baseConfig.whitelist[region] || baseConfig.whitelist.default;
-  const patterns = whitelist.map(makePattern);
-
-  log(`Selecting tests for region ${region} using patterns ${patterns}`);
-  if (!Object.keys(baseConfig).includes(region))
-    log('No test whitelist defined for region, using default');
-
-  return patterns;
-};
 
 module.exports = (on, config) => {
   // only include certain tests
@@ -80,3 +32,62 @@ module.exports = (on, config) => {
     env: process.env
   };
 };
+
+/**
+ * Extend browser arguments to immediately open dev tools so we can inspect breakpoint halts
+ * (when we added a "debugger" statement in our code
+ * @param {string[]} args - Command-line args Passed when the browser is launched,
+ * see https://docs.cypress.io/api/plugins/browser-launch-api.html#Modify-browser-launch-arguments-preferences-and-extensions
+ */
+function setAutoDevTools(args) {
+  args.push('--auto-open-devtools-for-tabs');
+}
+
+/**
+ * Extend browser arguments to set Chrome's window position and size
+ * Use an environment variable to control where the Chrome browser window will
+ * be opened by Cypress. As an example:
+ *
+ * $ cross-env CYPRESS_BROWSER_WINDOW="1920,1080;1920,0" npm run test:e2e-chrome
+ *
+ * would run cypress tests with a window of size 1920x1080 with its upper left
+ * corner at 1920,0 on the monitor.
+ *
+ * @param {string[]} args - Command-line args Passed when the browser is launched,
+ * see https://docs.cypress.io/api/plugins/browser-launch-api.html#Modify-browser-launch-arguments-preferences-and-extensions
+ */
+function setWindowPos(args) {
+  const { cypressBrowserWindow } = process.env;
+  if (cypressBrowserWindow == null) return;
+
+  const [windowSize, windowPosition] = cypressBrowserWindow.split(';');
+  args.push(
+    '--user-data-dir="~/chrome-test-user"',
+    `--window-size=${windowSize}`,
+    `--window-position=${windowPosition}`
+  );
+}
+
+/**
+ * Generate an array of pattern for selecting tests to run
+ *
+ * Expects an environment variable `REGION` with a corresponding entry
+ * in `cypress.json` under the key `whitelist`, containing an array of
+ * path segments to match for.
+ *
+ * @returns string[] A list of file patterns
+ */
+function getPatternsForRegion() {
+  const makePattern = (page) => `**/${page}/**/*.e2e.test.js`;
+
+  const region = process.env.REGION;
+  const whitelist =
+    baseConfig.whitelist[region] || baseConfig.whitelist.default;
+  const patterns = whitelist.map(makePattern);
+
+  log(`Selecting tests for region ${region} using patterns ${patterns}`);
+  if (!Object.keys(baseConfig).includes(region))
+    log('No test whitelist defined for region, using default');
+
+  return patterns;
+}

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,37 +1,9 @@
-/* eslint-disable no-use-before-define */
 require('dotenv').config();
 const wp = require('@cypress/webpack-preprocessor');
 
 const log = require('debug')('cypress:plugins');
-
 const baseConfig = require('../../cypress.json');
 const webpackOptions = require('../../webpack/webpack.config.dev.js');
-
-module.exports = (on, config) => {
-  // only include certain tests
-  const testFiles = getPatternsForRegion();
-
-  // modify the way browsers are launched,
-  // see https://docs.cypress.io/api/plugins/browser-launch-api.html#Usage
-  on('before:browser:launch', (browser = {}, launchOptions) => {
-    if (browser.name === 'chrome') {
-      const { args } = launchOptions;
-      setAutoDevTools(args);
-      setWindowPos(args);
-    }
-    return launchOptions;
-  });
-
-  on('file:preprocessor', wp({ webpackOptions }));
-
-  // store process env in cypress env,
-  // see https://docs.cypress.io/guides/guides/environment-variables.html#Option-2-cypress-env-json
-  return {
-    ...config,
-    testFiles,
-    env: process.env
-  };
-};
 
 /**
  * Extend browser arguments to immediately open dev tools so we can inspect breakpoint halts
@@ -91,3 +63,31 @@ function getPatternsForRegion() {
 
   return patterns;
 }
+
+const DynamicCypressConfig = (on, config) => {
+  // only include certain tests
+  const testFiles = getPatternsForRegion();
+
+  // modify the way browsers are launched,
+  // see https://docs.cypress.io/api/plugins/browser-launch-api.html#Usage
+  on('before:browser:launch', (browser = {}, launchOptions) => {
+    if (browser.name === 'chrome') {
+      const { args } = launchOptions;
+      setAutoDevTools(args);
+      setWindowPos(args);
+    }
+    return launchOptions;
+  });
+
+  on('file:preprocessor', wp({ webpackOptions }));
+
+  // store process env in cypress env,
+  // see https://docs.cypress.io/guides/guides/environment-variables.html#Option-2-cypress-env-json
+  return {
+    ...config,
+    testFiles,
+    env: process.env
+  };
+};
+
+module.exports = DynamicCypressConfig;


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List updates to dependencies that are
required for this change.

Fixes https://github.com/FixMyBerlin/fixmy.platform/issues/404

## Type of change

Implements the need to migrate the call signature of Cypress´ `on('before:browser:launch)` callback, which is [described here](https://docs.cypress.io/guides/references/migration-guide.html#Plugin-Event-before-browser-launch).

## How Has This Been Tested?

- Run `npm start` and - once the dev server booted - `test:e2e-chrome`
- [ ] The deprecation warning is not shown anymore
- [ ] Dev Tools still fold out without the need to do it manually

## Anything else to remark?

* I could not customize the browser position as it is documented for `setWindowPos`, this needs another look @ciex 
* I opened https://github.com/FixMyBerlin/fixmy.platform/issues/407 to finally get rid of `/* eslint-disable no-use-before-define */` that has been added here yet another time 
