### PR TITLE
Disable reports app for Aachen region

### DIFF
--- a/src/pages/Reports/config/aachen.js
+++ b/src/pages/Reports/config/aachen.js
@@ -2,6 +2,7 @@ import AachenLogo from '~/images/aachen/logo-stadt-aachen-bg.png';
 import LandingBackground from '~/images/aachen/landing_background.jpg';
 
 export default {
+  enabled: false,
   overviewMap: {
     style: 'mapbox://styles/hejco/ck7q440d50b6s1ip928c7zlbb',
     bounds: [
@@ -57,7 +58,7 @@ export default {
   },
   region: 'Aachen',
   intro:
-    'Damit Sie Ihr Fahrrad überall sicher abschließen können, baut die Stadt Aachen umfassend neue Fahrradabstellmöglichkeiten aus. Da Sie  als Bürger*in am besten wissen, wo Sie Ihr Fahrrad abstellen, können Sie hier melden, wo genau Sie neue Bügel benötigen.',
+    'Damit Sie Ihr Fahrrad überall sicher abschließen können, baut die Stadt Aachen umfassend neue Fahrradabstellmöglichkeiten aus. Bürger*innen haben auf dieser Seite von April bis August 2020 gemeldet, wo genau sie Radbügel benötigen, so dass die Stadt diese jetzt bedarfsgerecht aufstellen kann.',
   steps: [
     {
       step: 1,

--- a/src/pages/Reports/config/berlin.js
+++ b/src/pages/Reports/config/berlin.js
@@ -5,6 +5,7 @@ import BycicleParkingBgImg from '~/images/reports/bycicle-parking@3x.png';
 import BycicleParkingBgImgLargeScreen from '~/images/reports/landing-christin-hume-595752-unsplash.jpg';
 
 export default {
+  enabled: false,
   overviewMap: {
     style: 'mapbox://styles/hejco/cjpnt0cc41ipy2rlpu19jgt7a',
     bounds: [
@@ -49,7 +50,6 @@ export default {
     stepColors: [config.colors.interaction, '#ff99d5', config.colors.black]
   },
   form: { placementNotice: true },
-  reportsDisabled: true,
   markerSet: 'default',
   tests: {
     addressInput: 'meh',

--- a/src/pages/Reports/index.tsx
+++ b/src/pages/Reports/index.tsx
@@ -24,7 +24,16 @@ class Reports extends PureComponent {
             path={`${config.routes.reports.map}/:id?`}
             component={OverviewMap}
           />
-          <Route path={config.routes.reports.new} component={SubmitReport} />
+          <Route
+            path={config.routes.reports.new}
+            render={(props) =>
+              config.reports.enabled ? (
+                <SubmitReport {...props} />
+              ) : (
+                <Redirect to={config.routes.reports.landing} />
+              )
+            }
+          />
           <Route
             exact
             path={config.routes.reports.index}

--- a/src/pages/Reports/pages/Landing/TopSection.tsx
+++ b/src/pages/Reports/pages/Landing/TopSection.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import styled from 'styled-components';
+import { Dispatch } from 'redux';
+import { History } from 'history';
 
 import config from '~/pages/Reports/config';
 import { actions } from '~/pages/Reports/state/SubmitReportState';
@@ -148,9 +150,13 @@ const OnlyMobile = styled.span`
   `}
 `;
 
-const navigateToMap = (dispatch, history) => {
+const navigateToMap = (dispatch: Dispatch, history: History) => {
   dispatch(actions.setLocationModeGeocoding());
   history.push(config.routes.reports.new);
+};
+
+const navigateToOverview = (dispatch: Dispatch, history: History) => {
+  history.push(config.routes.reports.map);
 };
 
 const ModeChooserLink = () => (
@@ -162,18 +168,28 @@ const ModeChooserLink = () => (
   </StyledButton>
 );
 
-const MapButton = ({ onClick }) => (
+const MapButton = ({ onClick, children = null }) => (
   <StyledButton
     className="wiggle"
     data-cy="reports-landing-cta"
     onClick={onClick}
   >
-    <strong>Sagen Sie uns wo</strong>
-    <br /> in 30 Sekunden
+    {!children && (
+      <>
+        <strong>Sagen Sie uns wo</strong>
+        <br /> in 30 Sekunden
+      </>
+    )}
+    {children}
   </StyledButton>
 );
 
-const TopSection = ({ dispatch, history }) => (
+type Props = {
+  dispatch: Dispatch;
+  history: History;
+};
+
+const TopSection = ({ dispatch, history }: Props) => (
   <Section>
     <MenuButton whiteFill="true" />
     <FlexWrapper>
@@ -188,12 +204,21 @@ const TopSection = ({ dispatch, history }) => (
       <StyledHeading data-cy="reports-landing-header">
         {config.reports.landing?.title}
       </StyledHeading>
-      <OnlyMobile>
-        <ModeChooserLink />
-      </OnlyMobile>
-      <OnlyDesktop>
-        <MapButton onClick={() => navigateToMap(dispatch, history)} />
-      </OnlyDesktop>
+      {config.reports.enabled && (
+        <>
+          <OnlyMobile>
+            <ModeChooserLink />
+          </OnlyMobile>
+          <OnlyDesktop>
+            <MapButton onClick={() => navigateToMap(dispatch, history)} />
+          </OnlyDesktop>
+        </>
+      )}
+      {!config.reports.enabled && (
+        <MapButton onClick={() => navigateToOverview(dispatch, history)}>
+          Schauen Sie sich alle Meldungen an
+        </MapButton>
+      )}
     </FlexWrapper>
     <ScrollLink />
   </Section>

--- a/src/pages/Reports/pages/Landing/aachen.tsx
+++ b/src/pages/Reports/pages/Landing/aachen.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { media } from '~/styles/utils';
-import JoinButton from './components/JoinButton';
+import CTA from './components/CTA';
 import HowItWorksSection from './components/HowItWorksSecion';
 import Quote from './components/QuoteAachen';
 import MapLink from './components/MapLink';
 import Faq from './components/Faq';
 import HorizontalRuler from '~/pages/Reports/pages/SubmitReport/components/HorizontalRuler';
 import FahrRadLogo from '~/images/aachen/fahr-rad-logo@2x.png';
+import config from '~/pages/Reports/config';
 
 const BottomLogo = styled.img`
   margin: 5em auto 3em;
@@ -24,17 +25,21 @@ const LogoWrapper = styled.div`
   justify-content: center;
 `;
 
+const HR = styled(HorizontalRuler)`
+  margin-top: 2em;
+`;
+
 const AachenLanding = () => (
   <>
     <HowItWorksSection />
-    <HorizontalRuler className="light" />
+    <HR className="light" />
     <Quote />
-    <JoinButton />
-    <MapLink />
-    <HorizontalRuler className="light" />
+    <CTA />
+    {config.reports.enabled && <MapLink />}
+    <HR className="light" />
     <Faq />
-    <JoinButton />
-    <MapLink />
+    <CTA />
+    {config.reports.enabled && <MapLink />}
     <LogoWrapper>
       <BottomLogo src={FahrRadLogo} />
     </LogoWrapper>

--- a/src/pages/Reports/pages/Landing/berlin.tsx
+++ b/src/pages/Reports/pages/Landing/berlin.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import JoinButton from './components/JoinButton';
+import CTA from './components/CTA';
 import HowItWorksSection from './components/HowItWorksSecion';
 import Quote from './components/QuoteWeisbrich';
 import MapLink from './components/MapLink';
@@ -12,11 +12,11 @@ const BerlinLanding = () => (
     <HowItWorksSection />
     <HorizontalRuler className="light" />
     <Quote />
-    <JoinButton />
+    <CTA />
     <MapLink />
     <HorizontalRuler className="light" />
     <Faq />
-    <JoinButton />
+    <CTA />
     <MapLink />
   </>
 );

--- a/src/pages/Reports/pages/Landing/components/CTA.js
+++ b/src/pages/Reports/pages/Landing/components/CTA.js
@@ -27,14 +27,30 @@ const CenteredButton = styled(Button)`
   }
 `;
 
+const Note = styled.p`
+  max-width: 272px;
+  font-size: 14px;
+  font-weight: bold;
+  line-height: 1.4;
+  text-align: center;
+  margin: 1em auto 2em auto;
+`;
+
 const JoinButton = ({ toUrl }) => (
-  <Link to={toUrl}>
-    <CenteredButton>
-      {config.reports.enabled
-        ? 'Sagen Sie uns, wo Fahrradbügel benötigt werden'
-        : 'Schauen Sie sich alle Meldungen an'}
-    </CenteredButton>
-  </Link>
+  <>
+    <Link to={toUrl}>
+      <CenteredButton>
+        {config.reports.enabled
+          ? 'Sagen Sie uns, wo Fahrradbügel benötigt werden'
+          : 'Schauen Sie sich alle Meldungen an'}
+      </CenteredButton>
+    </Link>
+    {!config.reports.enabled && (
+      <Note>
+        Hinweis: Meldungen konnten bis zum 31. August 2020 eingereicht werden.
+      </Note>
+    )}
+  </>
 );
 
 JoinButton.propTypes = {

--- a/src/pages/Reports/pages/Landing/components/CTA.js
+++ b/src/pages/Reports/pages/Landing/components/CTA.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import Button from '~/components/Button';
 import config from '~/pages/Reports/config';
+import Link from '~/components/Link';
 
 const CenteredButton = styled(Button)`
   margin: 0 auto;
@@ -27,9 +28,13 @@ const CenteredButton = styled(Button)`
 `;
 
 const JoinButton = ({ toUrl }) => (
-  <CenteredButton as="a" href={toUrl}>
-    Sagen Sie uns, wo Fahrradbügel benötigt werden
-  </CenteredButton>
+  <Link to={toUrl}>
+    <CenteredButton>
+      {config.reports.enabled
+        ? 'Sagen Sie uns, wo Fahrradbügel benötigt werden'
+        : 'Schauen Sie sich alle Meldungen an'}
+    </CenteredButton>
+  </Link>
 );
 
 JoinButton.propTypes = {
@@ -37,7 +42,9 @@ JoinButton.propTypes = {
 };
 
 JoinButton.defaultProps = {
-  toUrl: `${config.routes.reports?.new}`
+  toUrl: config.reports.enabled
+    ? config.routes.reports.new
+    : config.routes.reports.map
 };
 
 export default JoinButton;

--- a/src/pages/Reports/pages/OverviewMap/components/CTAButton.js
+++ b/src/pages/Reports/pages/OverviewMap/components/CTAButton.js
@@ -42,19 +42,24 @@ const PlusIcon = styled(Plus)`
   box-sizing: content-box;
 `;
 
-const AddButton = ({ onTab, shiftLeft }) => (
+const CTAButton = ({ onTab, shiftLeft }) => (
   <Button onClick={onTab} className="wiggle" shiftLeft={shiftLeft}>
-    <PlusIcon /> Neue Meldung
+    {config.reports.enabled && (
+      <>
+        <PlusIcon /> Neue Meldung
+      </>
+    )}
+    {!config.reports.enabled && <>Mehr Infos</>}
   </Button>
 );
 
-AddButton.propTypes = {
+CTAButton.propTypes = {
   onTab: PropTypes.func.isRequired,
   shiftLeft: PropTypes.bool // if true, position more to the left to leave space for foldout
 };
 
-AddButton.defaultProps = {
+CTAButton.defaultProps = {
   shiftLeft: false
 };
 
-export default AddButton;
+export default CTAButton;

--- a/src/pages/Reports/pages/OverviewMap/index.js
+++ b/src/pages/Reports/pages/OverviewMap/index.js
@@ -154,7 +154,9 @@ class OverviewMap extends Component {
     const hasDetailId = match.params.id;
     const isDesktopView = matchMediaSize(breakpoints.m);
     const isCTAButtonShifted = isDesktopView && hasDetailId && !isMenuOpen;
-    const isCTAHidden = isDesktopView && hasDetailId && isMenuOpen;
+    const isCTAHidden =
+      (isDesktopView && hasDetailId && isMenuOpen) ||
+      config.region === 'berlin';
 
     const mapControls = (
       <>

--- a/src/pages/Reports/pages/OverviewMap/index.js
+++ b/src/pages/Reports/pages/OverviewMap/index.js
@@ -12,7 +12,7 @@ import config from '~/pages/Reports/config';
 import { matchMediaSize, breakpoints } from '~/styles/utils';
 import WebglMap from './components/WebglMap';
 import OverviewMapNavBar from './components/OverviewMapNavBar';
-import AddButton from './components/AddButton';
+import CTAButton from './components/CTAButton';
 import ErrorMessage from '~/components/ErrorMessage';
 import ReportsPopup from './components/ReportsPopup';
 import ReportDetails from './components/ReportDetails';
@@ -86,8 +86,12 @@ class OverviewMap extends Component {
     this.props.resetMapState();
   }
 
-  onAddButtonTab = () => {
-    this.props.history.push(config.routes.reports.new);
+  onCTAButtonTab = () => {
+    this.props.history.push(
+      config.reports.enabled
+        ? config.routes.reports.new
+        : config.routes.reports.landing
+    );
   };
 
   onMarkerClick = (el, reportItem) => {
@@ -149,10 +153,8 @@ class OverviewMap extends Component {
     } = this.props;
     const hasDetailId = match.params.id;
     const isDesktopView = matchMediaSize(breakpoints.m);
-    const isAddButtonShifted = isDesktopView && hasDetailId && !isMenuOpen;
-    const isAddButtonHidden =
-      config.reports.reportsDisabled ||
-      (isDesktopView && hasDetailId && isMenuOpen);
+    const isCTAButtonShifted = isDesktopView && hasDetailId && !isMenuOpen;
+    const isCTAHidden = isDesktopView && hasDetailId && isMenuOpen;
 
     const mapControls = (
       <>
@@ -161,10 +163,10 @@ class OverviewMap extends Component {
           onChange={this.onLocationChange}
           customPosition={{ bottom: '105px', right: '7px' }}
         />
-        {!isAddButtonHidden && (
-          <AddButton
-            onTab={this.onAddButtonTab}
-            shiftLeft={isAddButtonShifted}
+        {!isCTAHidden && (
+          <CTAButton
+            onTab={this.onCTAButtonTab}
+            shiftLeft={isCTAButtonShifted}
           />
         )}
       </>

--- a/src/pages/Reports/pages/OverviewMap/index.js
+++ b/src/pages/Reports/pages/OverviewMap/index.js
@@ -151,6 +151,7 @@ class OverviewMap extends Component {
       isMenuOpen,
       errorMessage
     } = this.props;
+
     const hasDetailId = match.params.id;
     const isDesktopView = matchMediaSize(breakpoints.m);
     const isCTAButtonShifted = isDesktopView && hasDetailId && !isMenuOpen;

--- a/src/pages/Reports/tests/landing.unit.test.tsx
+++ b/src/pages/Reports/tests/landing.unit.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render } from '~/utils/test-utils';
+import Landing from '~/pages/Reports/pages/Landing';
+import config from '~/pages/Reports/config';
+
+describe('Landing page', () => {
+  beforeAll(() => {
+    jest.mock('~/pages/Reports/config');
+  });
+  it('renders when reports are enabled', () => {
+    const { getAllByRole } = render(<Landing />);
+    config.reports.enabled = true;
+    expect(
+      getAllByRole('button', { name: 'Schauen Sie sich alle Meldungen an' })
+    ).toHaveLength(2);
+  });
+  it('renders when reports are disabled', () => {
+    const { getAllByRole } = render(<Landing />);
+    config.reports.enabled = false;
+    expect(
+      getAllByRole('button', {
+        name: 'Sagen Sie uns, wo Fahrradbügel benötigt werden'
+      })
+    ).toHaveLength(2);
+  });
+});

--- a/src/utils/polyfill-intl.ts
+++ b/src/utils/polyfill-intl.ts
@@ -23,14 +23,14 @@ async function polyfill(locale: LocaleCode) {
 
   if ((Intl.PluralRules as any).polyfilled) {
     switch (locale) {
-      default:
-        await import('@formatjs/intl-pluralrules/locale-data/de');
-        break;
       case 'en':
         await import('@formatjs/intl-pluralrules/locale-data/en');
         break;
       case 'es':
         await import('@formatjs/intl-pluralrules/locale-data/es');
+        break;
+      default:
+        await import('@formatjs/intl-pluralrules/locale-data/de');
         break;
     }
   }
@@ -43,14 +43,14 @@ async function polyfill(locale: LocaleCode) {
 
   if ((Intl.NumberFormat as any).polyfilled) {
     switch (locale) {
-      default:
-        await import('@formatjs/intl-numberformat/locale-data/de');
-        break;
       case 'en':
         await import('@formatjs/intl-numberformat/locale-data/en');
         break;
       case 'es':
         await import('@formatjs/intl-numberformat/locale-data/es');
+        break;
+      default:
+        await import('@formatjs/intl-numberformat/locale-data/de');
         break;
     }
   }
@@ -66,11 +66,6 @@ async function polyfill(locale: LocaleCode) {
     const dataPolyfills = [import('@formatjs/intl-datetimeformat/add-all-tz')];
 
     switch (locale) {
-      default:
-        dataPolyfills.push(
-          import('@formatjs/intl-datetimeformat/locale-data/de')
-        );
-        break;
       case 'en':
         dataPolyfills.push(
           import('@formatjs/intl-datetimeformat/locale-data/en')
@@ -79,6 +74,11 @@ async function polyfill(locale: LocaleCode) {
       case 'es':
         dataPolyfills.push(
           import('@formatjs/intl-datetimeformat/locale-data/es')
+        );
+        break;
+      default:
+        dataPolyfills.push(
+          import('@formatjs/intl-datetimeformat/locale-data/de')
         );
         break;
     }

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -24,10 +24,10 @@ export const formatActionType = (pathedAction: string): string =>
 
 const Providers = ({ children }) => {
   const history = createMemoryHistory();
-  polyfill('de');
+  polyfill('en');
   return (
     <Provider store={Store}>
-      <IntlProvider defaultLocale="de" locale="de" messages={messages}>
+      <IntlProvider defaultLocale="en" locale="en" messages={messages}>
         <Router history={history}>{children}</Router>
       </IntlProvider>
     </Provider>


### PR DESCRIPTION
- redirect from "new reports"-route to reports landing page
- update reports landing page text content for disabled app-state (mostly the description following the first fold)
- replace CTA on landing page with a link to the overview map
- replace CTA on overview map with a link to the reports landing page