### PR TITLE
Fix reports overview map CTA not handling click until data loaded

### DIFF
--- a/src/components/BigLoader.js
+++ b/src/components/BigLoader.js
@@ -22,6 +22,8 @@ const WrapperAbsolute = styled(BaseWrapper)`
   top: 0;
   left: 0;
   z-index: 1000;
+  /* let through clicks */
+  pointer-events: none;
 `;
 
 const BigLoader = ({ useAbsolutePositioning }) => {


### PR DESCRIPTION
closes https://github.com/FixMyBerlin/fixmy.platform/issues/429

The wrapper for the BigLoader (the variant using absolute positioning) is displayed on top of all content by giving it a high `zIndex`. This prevents underlying content from being clicked.
The fix ist to add `pointer-events: none;`, which should be [safe to use](https://caniuse.com/pointer-events).

Fixes https://github.com/FixMyBerlin/fixmy.platform/issues/429

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

* Open https://radbuegel-aachen.de/meldungen/karte
* artificially throttle network performance with dev tools down to "slow 3g"
* select BigLoader wrapper, apply the css rule stated above
* wait for the button to show, click it

Routing should be triggered.