### PR TITLE
Add detail panel for linked report entries

### DIFF
--- a/src/pages/Reports/pages/OverviewMap/components/ReportDetails/Body.js
+++ b/src/pages/Reports/pages/OverviewMap/components/ReportDetails/Body.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import Link from '~/components/Link';
 import SubHeading from '~/pages/Reports/pages/SubmitReport/components/SubHeading';
 // import HorizontalRuler from '~/pages/Reports/pages/SubmitReport/components/HorizontalRuler';
 import config from '~/pages/Reports/config';
+import { getReportStatusCaption } from '~/pages/Reports/apiservice';
 
 const IndicatorSection = styled.div`
   display: flex;
@@ -36,9 +38,19 @@ const IndicatorValue = styled(Text)`
 //   });
 // }
 
+const EntryLink = styled(Link)`
+  && {
+    color: ${config.colors.black};
+    border-bottom: 1px solid ${config.colors.interaction};
+    line-height: 1.6;
+  }
+`;
+
 const DetailsBody = ({
   description,
-  details: { fee_acceptable: isFeeAcceptable }
+  details: { fee_acceptable: isFeeAcceptable },
+  origin,
+  plannings
   // created_date: createdDate
 }) => (
   <>
@@ -48,12 +60,45 @@ const DetailsBody = ({
         <Text data-cy="reports-detail-description">{description}</Text>
       </>
     )}
-
     <IndicatorSection>
       <IndicatorTitle>Bedarf Fahrradparkhaus:</IndicatorTitle>
       <IndicatorValue>{isFeeAcceptable ? 'ja' : 'nein'}</IndicatorValue>
     </IndicatorSection>
 
+    {origin.length > 0 && (
+      <>
+        <SubHeading alignLeft>Eingeflossene Meldungen</SubHeading>
+        <p>Folgende Meldungen sind in dieser Planung berücksichtigt worden:</p>
+        <ul>
+          {origin.map((source) => (
+            <li key={`origin-${source.id}`}>
+              <EntryLink to={`${config.routes.reports.map}/${source.id}`}>
+                {source.address}
+              </EntryLink>
+            </li>
+          ))}
+        </ul>
+      </>
+    )}
+
+    {plannings.length > 0 && (
+      <>
+        <SubHeading alignLeft>Umsetzung in der Nähe</SubHeading>
+        <p>
+          In der unmittelbaren Nähe dieses Vorschlags werden Radbügel an
+          folgenden Standorten umgesetzt:
+        </p>
+        <ul>
+          {plannings.map((source) => (
+            <li key={`planning-${source.id}`}>
+              <EntryLink to={`${config.routes.reports.map}/${source.id}`}>
+                {source.address} ({getReportStatusCaption(source.status)})
+              </EntryLink>
+            </li>
+          ))}
+        </ul>
+      </>
+    )}
     {/*
     <HorizontalRuler className="light" />
 

--- a/src/pages/Reports/pages/OverviewMap/components/ReportDetails/ReportDetails.unit.test.js
+++ b/src/pages/Reports/pages/OverviewMap/components/ReportDetails/ReportDetails.unit.test.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+
+import Body from './Body';
+
+const reportData = {
+  description: 'Description',
+  details: {
+    fee_acceptable: true
+  },
+  origin: [
+    {
+      id: 1,
+      address: 'test'
+    }
+  ],
+  plannings: [
+    {
+      id: 2,
+      address: 'test2'
+    }
+  ]
+};
+
+describe('<Body />', () => {
+  it('renders origin reports', () => {
+    const history = createMemoryHistory();
+    const originData = { ...reportData, plannings: [] };
+    render(
+      <Router history={history}>
+        <Body {...originData} />
+      </Router>
+    );
+    expect(screen.getByRole('link')).toHaveTextContent(
+      reportData.origin[0].address
+    );
+  });
+  it("renders reports' linked plannings", () => {
+    const history = createMemoryHistory();
+    const planningData = { ...reportData, origin: [] };
+    render(
+      <Router history={history}>
+        <Body {...planningData} />
+      </Router>
+    );
+    expect(screen.getByRole('link')).toHaveTextContent(
+      reportData.plannings[0].address
+    );
+  });
+});


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List updates to dependencies that are
required for this change.

Closes #578

## How Has This Been Tested?

Use the Django admin interface to link a bike stands planning to a report and vice versa. Open the entry's detail panel and observe that details about the linked entries are visible.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
