### PR TITLE
Planning map error handling

### DIFF
--- a/src/apps/Map/MapState.ts
+++ b/src/apps/Map/MapState.ts
@@ -18,7 +18,7 @@ const SET_PLANNING_FILTER = 'Map/MapState/SET_PLANNING_FILTER';
 const SET_POPUP_DATA = 'Map/MapState/SET_POPUP_DATA';
 const SET_POPUP_LOCATION = 'Map/MapState/SET_POPUP_LOCATION';
 const SET_POPUP_VISIBLE = 'Map/MapState/SET_POPUP_VISIBLE';
-const SET_PLANNING_DATA = 'Map/MapState/SET_PLANNING_DATA';
+export const SET_PLANNING_DATA = 'Map/MapState/SET_PLANNING_DATA';
 const SET_ERROR = 'Map/MapState/SET_ERROR';
 const UNSET_ERROR = 'Map/MapState/UNSET_ERROR';
 
@@ -231,7 +231,7 @@ export function setPopupVisible(isVisible: boolean): SetPopupVisible {
   return { type: SET_POPUP_VISIBLE, payload: { displayPopup: isVisible } };
 }
 
-interface LoadPlanningData {
+export interface LoadPlanningData {
   type: typeof SET_PLANNING_DATA;
   payload: {
     planningData: any;

--- a/src/apps/Map/MapState.ts
+++ b/src/apps/Map/MapState.ts
@@ -23,7 +23,7 @@ const SET_POPUP_DATA = 'Map/MapState/SET_POPUP_DATA';
 const SET_POPUP_LOCATION = 'Map/MapState/SET_POPUP_LOCATION';
 const SET_POPUP_VISIBLE = 'Map/MapState/SET_POPUP_VISIBLE';
 export const SET_PLANNING_DATA = 'Map/MapState/SET_PLANNING_DATA';
-const SET_ERROR = 'Map/MapState/SET_ERROR';
+export const SET_ERROR = 'Map/MapState/SET_ERROR';
 const UNSET_ERROR = 'Map/MapState/UNSET_ERROR';
 
 type MapView = 'zustand' | 'planungen';
@@ -53,7 +53,7 @@ export type MapState = MapConfig['view'] & {
   show3dBuildings: boolean;
 };
 
-const initialState: MapState = {
+export const initialState: MapState = {
   ...config.apps.map.view,
   activeView: null,
   activeSection: null,
@@ -136,7 +136,7 @@ export function setActiveView(activeView: MapView) {
   return { type: SET_VIEW_ACTIVE, payload: { activeView } };
 }
 
-type SetError = {
+export type SetError = {
   type: typeof SET_ERROR;
   payload: {
     error: string;

--- a/src/apps/Map/MapState.ts
+++ b/src/apps/Map/MapState.ts
@@ -5,6 +5,7 @@ import { Dispatch } from 'redux';
 
 import config from '~/config';
 import { MapConfig } from './types';
+import { get as apiGet } from '~/services/api/shorthands';
 
 const UPDATE_HISTORY = 'Map/MapState/UPDATE_HISTORY';
 const SET_ACTIVE_SECTION = 'Map/MapState/SET_ACTIVE_SECTION';
@@ -244,9 +245,8 @@ export function loadPlanningData() {
       return false;
     }
 
-    const planningData = await ky
-      .get(`${config.apiUrl}/projects?page_size=500`, { timeout: 50000 })
-      .json();
+    const apiRoute = `projects?page_size=500`;
+    const planningData = await apiGet(apiRoute);
 
     return dispatch({ type: SET_PLANNING_DATA, payload: { planningData } });
   };

--- a/src/apps/Map/MapState.ts
+++ b/src/apps/Map/MapState.ts
@@ -2,7 +2,7 @@ import { match, matchPath } from 'react-router-dom';
 import qs from 'qs';
 import ky from 'ky';
 import { Dispatch } from 'redux';
-import { ThunkAction } from 'redux-thunk';
+import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 
 import config from '~/config';
 import { MapConfig } from './types';
@@ -251,13 +251,19 @@ export function setPlanningData(apiResponse): SetPlanningData {
   };
 }
 
-export function loadPlanningData(): ThunkAction<
+export type SetPlanningsThunk = ThunkAction<
   void,
   Pick<RootState, 'MapState'>,
   unknown,
   SetPlanningData | SetError
-> {
-  return async (dispatch, getState) => {
+>;
+export type SetPlanningsThunkDispatch = ThunkDispatch<
+  Pick<RootState, 'MapState'>,
+  null,
+  SetPlanningData | SetError
+>;
+export function loadPlanningData(): SetPlanningsThunk {
+  return async (dispatch: SetPlanningsThunkDispatch, getState) => {
     // early exit: do not fetch data if that data is already in the store
     const isStoreAlreadyPopulated = getState().MapState.planningData;
     if (isStoreAlreadyPopulated) {

--- a/src/apps/Map/MapState.ts
+++ b/src/apps/Map/MapState.ts
@@ -258,11 +258,12 @@ export function loadPlanningData(): ThunkAction<
   SetPlanningData | SetError
 > {
   return async (dispatch, getState) => {
+    // early exit: do not fetch data if that data is already in the store
     const isStoreAlreadyPopulated = getState().MapState.planningData;
     if (isStoreAlreadyPopulated) {
       return;
     }
-
+    // all good, fetch the data and handle errors
     try {
       const apiRoute = `projects?page_size=500`;
       const apiResponse = await apiGet(apiRoute);

--- a/src/apps/Map/MapState.unit.test.ts
+++ b/src/apps/Map/MapState.unit.test.ts
@@ -2,7 +2,7 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { rest } from 'msw';
 import {
-  LoadPlanningData,
+  SetPlanningData,
   loadPlanningData,
   MapState,
   SET_PLANNING_DATA
@@ -105,7 +105,7 @@ describe('Plannings Map Unit tests', () => {
       await store.dispatch(loadPlanningsThunk);
 
       /* ASSERT: action containing the api response has been dispatched */
-      const expectedAction: LoadPlanningData = {
+      const expectedAction: SetPlanningData = {
         type: SET_PLANNING_DATA,
         payload: { planningData: response as any }
       };

--- a/src/apps/Map/MapState.unit.test.ts
+++ b/src/apps/Map/MapState.unit.test.ts
@@ -9,7 +9,8 @@ import mapStateReducer, {
   SET_ERROR,
   SET_PLANNING_DATA,
   SetError,
-  SetPlanningData
+  SetPlanningData,
+  SetPlanningsThunkDispatch
 } from '~/apps/Map/MapState';
 
 import { RootState } from '~/store';
@@ -35,8 +36,7 @@ describe('Plannings Map Unit tests', () => {
 
       /* ACT: invoke loadPlanningsThunk */
       const loadPlanningsThunk = loadPlanningData();
-      // @ts-ignore FIXME: properly type this
-      await store.dispatch(loadPlanningsThunk);
+      await (store.dispatch as SetPlanningsThunkDispatch)(loadPlanningsThunk);
 
       /* ASSERT: no action should have been called */
       expect(store.getActions()).toHaveLength(0);
@@ -107,8 +107,7 @@ describe('Plannings Map Unit tests', () => {
 
       /* ACT: invoke thunk */
       const loadPlanningsThunk = loadPlanningData();
-      // @ts-ignore FIXME: properly type this
-      await store.dispatch(loadPlanningsThunk);
+      await (store.dispatch as SetPlanningsThunkDispatch)(loadPlanningsThunk);
 
       /* ASSERT: action containing the api response has been dispatched */
       const expectedAction: SetPlanningData = {
@@ -135,8 +134,7 @@ describe('Plannings Map Unit tests', () => {
 
         /* ACT: invoke loadPlanningsThunk; read dispatched actions and compute derived state */
         const loadPlanningsThunk = loadPlanningData();
-        // @ts-ignore FIXME: properly type this
-        await store.dispatch(loadPlanningsThunk);
+        await (store.dispatch as SetPlanningsThunkDispatch)(loadPlanningsThunk);
         const actualActions = store.getActions();
         const actualState = actualActions.reduce((state: MapState, action) => {
           return mapStateReducer(state, action);

--- a/src/apps/Map/MapState.unit.test.ts
+++ b/src/apps/Map/MapState.unit.test.ts
@@ -1,0 +1,115 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { rest } from 'msw';
+import {
+  LoadPlanningData,
+  loadPlanningData,
+  MapState,
+  SET_PLANNING_DATA
+} from '~/apps/Map/MapState';
+import config from '~/config';
+import { mswServer } from '../../../jest/msw/mswServer';
+import { RootState } from '~/store';
+
+describe('Plannings Map Unit tests', () => {
+  describe('loadPlanningData() thunk', () => {
+    const mockStore = configureMockStore([thunk]);
+
+    it('does not dispatch any actions if plannings data has been fetched already', async () => {
+      /* ARRANGE: mock store with initial state */
+      const preSeededMapState = {
+        planningData: true
+      } as MapState; // omitting non-relevant props
+      const preSeededRootState = {
+        MapState: preSeededMapState
+      } as RootState;
+      const store = mockStore(preSeededRootState);
+
+      /* ACT: invoke loadPlanningsThunk */
+      const loadPlanningsThunk = loadPlanningData();
+      // @ts-ignore FIXME: properly type this
+      await store.dispatch(loadPlanningsThunk);
+
+      /* ASSERT: no action should have been called */
+      expect(store.getActions()).toHaveLength(0);
+    });
+
+    it(`dispatches ${SET_PLANNING_DATA} once the plannings JSON has been fetched successfully`, async () => {
+      /* ARRANGE: mock store, intercept request and mock response */
+      const store = mockStore({
+        MapState: {} as MapState
+      });
+
+      const response = {
+        count: 245,
+        next: 'https://fixmyberlin.de/api/projects?page=2&page_size=1',
+        previous: null,
+        results: [
+          {
+            id: 4,
+            url: 'https://fixmyberlin.de/api/projects/4',
+            project_key: 'FK-020',
+            title: 'Neue Fahrradstraße',
+            description:
+              'Die Glogauer Straße ist als Zubringer zum Görlitzer Park und Durchfahrt zur Oberbaumbrücke eine stark befahrene Radstrecke. Die Straße soll daher als Fahrradstraße umgwidmet werden. Die Machbarkeit soll im Jahr 2019 geprüft und bei einem positivem Ergebnis voraussichtlich in 2019 umgesetzt werden.',
+            short_description:
+              'Die Glogauer Straße wird zu einer Fahrradstraße.',
+            category: 'bike street',
+            street_name: 'Glogauer Straße',
+            borough: 'Friedrichshain-Kreuzberg',
+            side: 2,
+            costs: null,
+            draft_submitted: null,
+            construction_started: null,
+            construction_completed: 'unbekannt',
+            construction_completed_date: null,
+            phase: 'draft',
+            responsible: 'Bezirksamt Friedrichshain-Kreuzberg',
+            external_url: null,
+            cross_section: null,
+            faq: [],
+            geometry: {
+              type: 'LineString',
+              coordinates: [
+                [13.435653786621, 52.4916709861841],
+                [13.4357418335253, 52.4917627197358],
+                [13.4374143916796, 52.4934570093144],
+                [13.4389228394647, 52.4949934633041]
+              ]
+            },
+            center: {
+              type: 'Point',
+              coordinates: [13.4374143916796, 52.4934570093144]
+            },
+            length: 431.0,
+            photos: [
+              {
+                copyright: 'Photo by Anthony Ginsbrook',
+                src:
+                  'https://fmb-aws-bucket.s3.amazonaws.com/photos/Platzhalter_anthony-ginsbrook-225252-unsplash.jpg'
+              }
+            ],
+            likes: 4
+          }
+        ]
+      };
+      mswServer.use(
+        rest.get(`${config.apiUrl}/projects`, (_, res, ctx) =>
+          res(ctx.json(response))
+        )
+      );
+
+      /* ACT: invoke thunk */
+      const loadPlanningsThunk = loadPlanningData();
+      // @ts-ignore FIXME: properly type this
+      await store.dispatch(loadPlanningsThunk);
+
+      /* ASSERT: action containing the api response has been dispatched */
+      const expectedAction: LoadPlanningData = {
+        type: SET_PLANNING_DATA,
+        payload: { planningData: response as any }
+      };
+      expect(store.getActions()).toEqual([expectedAction]);
+    });
+  });
+});

--- a/src/services/api/mapError.ts
+++ b/src/services/api/mapError.ts
@@ -9,7 +9,9 @@ const log = debug('fmc:api:mapError');
  * Translate errors reported by ky/fetch to a set of custom exceptions
  * which we can later on use to make decisions on how to handle specific errors.
  */
-export default async function mapError(e: FMCError): Promise<FMCError> {
+export default async function mapError(
+  e: Error
+): Promise<NetworkError | ApiError | TimeoutError | Error> {
   let errorMessage: string;
   let statusCode: number;
 
@@ -21,8 +23,8 @@ export default async function mapError(e: FMCError): Promise<FMCError> {
   // handle all other errors
   switch (e.constructor) {
     case ky.HTTPError: // a non 2xx error code was found
-      errorMessage = await parseErrorResponse(e.response);
-      statusCode = e.response.status;
+      errorMessage = await parseErrorResponse((e as FMCError).response);
+      statusCode = (e as FMCError).response.status;
       return new ApiError(errorMessage, statusCode);
     case ky.TimeoutError:
       return new TimeoutError(e.message);

--- a/src/services/api/shorthands.ts
+++ b/src/services/api/shorthands.ts
@@ -1,4 +1,3 @@
-import { Options as KyOptions } from 'ky';
 import { JSONValue, RequestOptions } from './types';
 import request from './request';
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,5 @@
 import { createStore, compose, applyMiddleware, combineReducers } from 'redux';
-import thunk from 'redux-thunk';
+import thunk, { ThunkAction } from 'redux-thunk';
 
 import AppState from '~/AppState';
 import UserState from '~/pages/User/UserState';

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,5 @@
 import { createStore, compose, applyMiddleware, combineReducers } from 'redux';
-import thunk, { ThunkAction } from 'redux-thunk';
+import thunk from 'redux-thunk';
 
 import AppState from '~/AppState';
 import UserState from '~/pages/User/UserState';


### PR DESCRIPTION
##

TODOs:
- [ ] remove ts-ignores
- [ ] UI/UX part (see the issue)

* adds error handling to to the plannings GET request, covers it with tests

Fixes #/543

## How Has This Been Tested?

Unit tests have been added

