### PR TITLE
Add missing polyfill import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20299,7 +20299,10 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icu4c-data": "^0.67.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -21540,6 +21543,12 @@
           }
         }
       }
+    },
+    "icu4c-data": {
+      "version": "0.67.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
+      "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
+      "dev": true
     },
     "idx": {
       "version": "2.5.6",
@@ -32370,9 +32379,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.4",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "prettier": "^2.2.0",
     "react-svg-loader": "^3.0.3",
     "redux-mock-store": "^1.5.4",
+    "regenerator-runtime": "^0.13.7",
     "request": "^2.88.2",
     "start-server-and-test": "^1.11.6",
     "style-loader": "^2.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
+import '~/utils/polyfills';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
-import '~/utils/polyfills';
 import Store from '~/store';
 import App from '~/App';
 

--- a/src/utils/polyfills.js
+++ b/src/utils/polyfills.js
@@ -2,6 +2,9 @@
  * All necessary polyfills should be required here
  * */
 
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 // we need this because the ky package needs fetch and it does not get added automatically with @babel/preset-env
 import 'whatwg-fetch';
 


### PR DESCRIPTION
Add missing core-js import to polyfill file and move polyfill import above React in entry file.

Closes https://github.com/FixMyBerlin/fixmy.frontend/issues/688

## How Has This Been Tested?

Visit /planungen using Internet Explorer 11

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
