### PR TITLE
Add loading animation to projects map

### DIFF
--- a/src/apps/Analysis/components/PieChart.tsx
+++ b/src/apps/Analysis/components/PieChart.tsx
@@ -8,7 +8,7 @@ import { setPhaseFilter } from '~/apps/Analysis/state';
 
 import { numberFormat, getRVALength, percentageFormat } from '~/utils/utils';
 import SvgIcon from '~/components/SvgIcon';
-import DotLoader from '~/components/DotLoader';
+import { DotLoader } from '~/components2/Loaders';
 import { PLANNING_PHASES } from '~/apps/Map/constants';
 
 const PieChartWrapper = styled.figure`

--- a/src/apps/Gastro/pages/Renewal.tsx
+++ b/src/apps/Gastro/pages/Renewal.tsx
@@ -11,7 +11,7 @@ import { GastroRegistration } from '../types';
 import Header from '../components/Header';
 import config from '../config';
 import api from '../api';
-import BigLoader from '~/components/BigLoader';
+import { BigLoader } from '~/components2/Loaders';
 
 const log = debug('fmc:gastro:renewal');
 

--- a/src/apps/Map/components/WebglMap/WebglMap.js
+++ b/src/apps/Map/components/WebglMap/WebglMap.js
@@ -24,6 +24,7 @@ import {
   setPopupLanesFilter,
 } from '~/apps/Map/map-utils';
 import resetMap from '~/apps/Map/reset';
+import { BigLoader } from '~/components2/Loaders';
 
 let MB_STYLE_URL;
 if (config.debug) {
@@ -346,6 +347,9 @@ class Map extends PureComponent {
       this.props.activeView === 'planungen' ||
       this.props.activeView === 'popupbikelanes';
 
+    const isLoading =
+      this.state.loading || this.props.planningDataFetchState === 'pending';
+
     return (
       <StyledMap
         className={this.props.className}
@@ -354,6 +358,7 @@ class Map extends PureComponent {
         }}
       >
         {this.props.children}
+        {isLoading && <BigLoader useAbsolutePositioning />}
         <ProjectMarkers
           map={this.state.map}
           data={markerData}
@@ -381,6 +386,7 @@ export default withRouter(
     hasMoved: state.MapState.hasMoved,
     pitch: state.MapState.pitch,
     planningData: state.MapState.planningData,
+    planningDataFetchState: state.MapState.planningDataFetchState,
     show3dBuildings: state.MapState.show3dBuildings,
     zoom: state.MapState.zoom,
     ...state.UserState,

--- a/src/apps/Map/tests/MapState.unit.test.ts
+++ b/src/apps/Map/tests/MapState.unit.test.ts
@@ -21,7 +21,7 @@ describe('Plannings Map Unit tests', () => {
 
     it('does not dispatch any actions if plannings data has been fetched already', async () => {
       const store = mockStore({
-        // @ts-expect-error this is not a complete map state, but it should be enough
+        // @ts-ignore this is not a complete `MapState` but it should suffice
         MapState: {
           planningDataFetchState: 'success',
         },
@@ -32,7 +32,7 @@ describe('Plannings Map Unit tests', () => {
 
     it(`dispatches ${SET_PLANNING_DATA} once the plannings JSON has been fetched successfully`, async () => {
       const store = mockStore({
-        // @ts-expect-error this is not a complete map state
+        // @ts-ignore this is not a complete `MapState` but it should suffice
         MapState: {
           planningDataFetchState: 'waiting',
         },

--- a/src/apps/Map/tests/MapState.unit.test.ts
+++ b/src/apps/Map/tests/MapState.unit.test.ts
@@ -1,20 +1,18 @@
+import { AnyAction } from 'redux';
 import configureMockStore from 'redux-mock-store';
 import thunk, { ThunkDispatch } from 'redux-thunk';
 import { rest } from 'msw';
+
+import { mswServer } from '~/../jest/msw/mswServer';
 import {
-  LoadPlanningData,
   loadPlanningData,
-  MapState,
   setPlanningData,
   setPlanningDataFetchState,
   SET_PLANNING_DATA,
 } from '~/apps/Map/MapState';
 import config from '~/config';
-import { mswServer } from '../../../../jest/msw/mswServer';
 import { RootState } from '~/store';
 import planningsResponseFixture from './fixtures/planningsResponse.json';
-import { AnyAction } from 'redux';
-import logger from '~/utils/logger';
 
 describe('Plannings Map Unit tests', () => {
   describe('loadPlanningData() thunk', () => {
@@ -22,26 +20,17 @@ describe('Plannings Map Unit tests', () => {
     const mockStore = configureMockStore<RootState, DispatchExts>([thunk]);
 
     it('does not dispatch any actions if plannings data has been fetched already', async () => {
-      /* ARRANGE: mock store with initial state */
-      const preSeededMapState = {
-        planningData: true,
-      } as MapState; // omitting non-relevant props
-      const preSeededRootState = {
-        MapState: preSeededMapState,
-      } as RootState;
-      const store = mockStore(preSeededRootState);
-
-      /* ACT: invoke loadPlanningsThunk */
-      const loadPlanningsThunk = loadPlanningData();
-      // @ts-ignore FIXME: properly type this
-      await store.dispatch(loadPlanningsThunk);
-
-      /* ASSERT: no action should have been called */
+      const store = mockStore({
+        // @ts-expect-error this is not a complete map state, but it should be enough
+        MapState: {
+          planningDataFetchState: 'success',
+        },
+      });
+      await store.dispatch(loadPlanningData());
       expect(store.getActions()).toHaveLength(0);
     });
 
     it(`dispatches ${SET_PLANNING_DATA} once the plannings JSON has been fetched successfully`, async () => {
-      /* ARRANGE: mock store, intercept request and mock response */
       const store = mockStore({
         // @ts-expect-error this is not a complete map state
         MapState: {
@@ -49,20 +38,17 @@ describe('Plannings Map Unit tests', () => {
         },
       });
 
-      const response = planningsResponseFixture;
       mswServer.use(
         rest.get(`${config.apiUrl}/projects`, (_, res, ctx) =>
-          res(ctx.json(response))
+          res(ctx.json(planningsResponseFixture))
         )
       );
 
-      /* ACT: invoke thunk */
       await store.dispatch(loadPlanningData());
 
-      /* ASSERT: action containing the api response has been dispatched */
       const expectedActions: AnyAction[] = [
         setPlanningDataFetchState('pending'),
-        setPlanningData(response),
+        setPlanningData(planningsResponseFixture),
         setPlanningDataFetchState('success'),
       ];
       expect(store.getActions()).toEqual(expectedActions);

--- a/src/apps/Map/tests/MapState.unit.test.ts
+++ b/src/apps/Map/tests/MapState.unit.test.ts
@@ -1,20 +1,25 @@
 import configureMockStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
+import thunk, { ThunkDispatch } from 'redux-thunk';
 import { rest } from 'msw';
 import {
   LoadPlanningData,
   loadPlanningData,
   MapState,
+  setPlanningData,
+  setPlanningDataFetchState,
   SET_PLANNING_DATA,
 } from '~/apps/Map/MapState';
 import config from '~/config';
 import { mswServer } from '../../../../jest/msw/mswServer';
 import { RootState } from '~/store';
 import planningsResponseFixture from './fixtures/planningsResponse.json';
+import { AnyAction } from 'redux';
+import logger from '~/utils/logger';
 
 describe('Plannings Map Unit tests', () => {
   describe('loadPlanningData() thunk', () => {
-    const mockStore = configureMockStore([thunk]);
+    type DispatchExts = ThunkDispatch<RootState, void, AnyAction>;
+    const mockStore = configureMockStore<RootState, DispatchExts>([thunk]);
 
     it('does not dispatch any actions if plannings data has been fetched already', async () => {
       /* ARRANGE: mock store with initial state */
@@ -38,7 +43,10 @@ describe('Plannings Map Unit tests', () => {
     it(`dispatches ${SET_PLANNING_DATA} once the plannings JSON has been fetched successfully`, async () => {
       /* ARRANGE: mock store, intercept request and mock response */
       const store = mockStore({
-        MapState: {} as MapState,
+        // @ts-expect-error this is not a complete map state
+        MapState: {
+          planningDataFetchState: 'waiting',
+        },
       });
 
       const response = planningsResponseFixture;
@@ -49,16 +57,15 @@ describe('Plannings Map Unit tests', () => {
       );
 
       /* ACT: invoke thunk */
-      const loadPlanningsThunk = loadPlanningData();
-      // @ts-ignore FIXME: properly type this
-      await store.dispatch(loadPlanningsThunk);
+      await store.dispatch(loadPlanningData());
 
       /* ASSERT: action containing the api response has been dispatched */
-      const expectedAction: LoadPlanningData = {
-        type: SET_PLANNING_DATA,
-        payload: { planningData: response as any },
-      };
-      expect(store.getActions()).toEqual([expectedAction]);
+      const expectedActions: AnyAction[] = [
+        setPlanningDataFetchState('pending'),
+        setPlanningData(response),
+        setPlanningDataFetchState('success'),
+      ];
+      expect(store.getActions()).toEqual(expectedActions);
     });
   });
 });

--- a/src/apps/Spielstrassen/pages/Register.tsx
+++ b/src/apps/Spielstrassen/pages/Register.tsx
@@ -9,7 +9,7 @@ import SignupForm from '~/apps/Spielstrassen/components/SignupForm';
 import SupporterIcon from '~/apps/Spielstrassen/components/SupporterIcon';
 import { RequestState } from '~/apps/Spielstrassen/state';
 import { getStreetInfo } from '~/apps/Spielstrassen/utils';
-import BigLoader from '~/components/BigLoader';
+import { BigLoader } from '~/components2/Loaders';
 import Header from '~/components2/Header';
 import config from '~/config';
 import { RootState } from '~/store';

--- a/src/components2/Loaders/BigLoader.tsx
+++ b/src/components2/Loaders/BigLoader.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropagateLoader from 'react-spinners/PropagateLoader';
-import PropTypes from 'prop-types';
 import config from '~/config';
 
 const BaseWrapper = styled.div`
@@ -26,21 +25,33 @@ const WrapperAbsolute = styled(BaseWrapper)`
   pointer-events: none;
 `;
 
-const BigLoader = ({ useAbsolutePositioning }) => {
+interface Props {
+  useAbsolutePositioning?: boolean;
+  className?: string;
+}
+
+/**
+ * Render a loading animation
+ *
+ * Color is set by `config.colors.interaction`
+ *
+ * @param arg0.useAbsolutePositioning: Switch static vs. absolute css position
+ * @param arg0.className: styled-components compatibility
+ */
+const BigLoader = ({ useAbsolutePositioning = false, className }: Props) => {
   const Wrapper = useAbsolutePositioning ? WrapperAbsolute : WrapperStatic;
   return (
-    <Wrapper>
+    <Wrapper
+      className={className}
+      role="progressbar"
+      aria-busy
+      aria-valuetext="loading"
+      aria-live="assertive"
+    >
+      <div aria-hidden>Wird geladen...</div>
       <PropagateLoader color={`${config.colors.interaction}`} />
     </Wrapper>
   );
-};
-
-BigLoader.propTypes = {
-  useAbsolutePositioning: PropTypes.bool,
-};
-
-BigLoader.defaultProps = {
-  useAbsolutePositioning: false,
 };
 
 export default BigLoader;

--- a/src/components2/Loaders/BigLoader.tsx
+++ b/src/components2/Loaders/BigLoader.tsx
@@ -45,10 +45,9 @@ const BigLoader = ({ useAbsolutePositioning = false, className }: Props) => {
       className={className}
       role="progressbar"
       aria-busy
-      aria-valuetext="loading"
+      aria-valuetext="Wird geladen"
       aria-live="assertive"
     >
-      <div aria-hidden>Wird geladen...</div>
       <PropagateLoader color={`${config.colors.interaction}`} />
     </Wrapper>
   );

--- a/src/components2/Loaders/DotLoader.tsx
+++ b/src/components2/Loaders/DotLoader.tsx
@@ -15,10 +15,9 @@ const DotLoader = () => (
   <LoaderWrapper
     role="progressbar"
     aria-busy
-    aria-valuetext="loading"
+    aria-valuetext="Wird geladen"
     aria-live="assertive"
   >
-    <div aria-hidden>Wird geladen...</div>
     <PropagateLoader color={`${config.colors.interaction}`} />
   </LoaderWrapper>
 );

--- a/src/components2/Loaders/Loaders.stories.js
+++ b/src/components2/Loaders/Loaders.stories.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Container } from '@material-ui/core';
+import { BigLoader, DotLoader } from '.';
+
+export default {
+  title: 'Generic / Loaders',
+  decorators: [
+    (fn) => (
+      <Container maxWidth="md" style={{ backgroundColor: '#eee' }}>
+        The loader is positioned inside this container
+        {fn()}
+      </Container>
+    ),
+  ],
+};
+
+export const Dot = () => <DotLoader />;
+export const Big = () => <BigLoader />;
+export const BigWithAbsolutePosition = () => (
+  <BigLoader useAbsolutePositioning />
+);

--- a/src/components2/Loaders/Loaders.unit.test.tsx
+++ b/src/components2/Loaders/Loaders.unit.test.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import { screen } from '@testing-library/dom';
 import { render } from '~/utils/test-utils';
-import { BigLoader } from '.';
+import { BigLoader, DotLoader } from '.';
 
 describe('<BigLoader />', () => {
   it('renders', () => {
     render(<BigLoader />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+});
+
+describe('<DotLoader />', () => {
+  it('renders', () => {
+    render(<DotLoader />);
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 });

--- a/src/components2/Loaders/Loaders.unit.test.tsx
+++ b/src/components2/Loaders/Loaders.unit.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { screen } from '@testing-library/dom';
+import { render } from '~/utils/test-utils';
+import { BigLoader } from '.';
+
+describe('<BigLoader />', () => {
+  it('renders', () => {
+    render(<BigLoader />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+});

--- a/src/components2/Loaders/index.ts
+++ b/src/components2/Loaders/index.ts
@@ -1,0 +1,1 @@
+export { default as BigLoader } from './BigLoader';

--- a/src/components2/Loaders/index.ts
+++ b/src/components2/Loaders/index.ts
@@ -1,1 +1,2 @@
 export { default as BigLoader } from './BigLoader';
+export { default as DotLoader } from './DotLoader';

--- a/src/components2/ProjectList/index.tsx
+++ b/src/components2/ProjectList/index.tsx
@@ -3,7 +3,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import ProjectListItem from './ProjectListItem';
 import ReportListItem from './ReportListItem';
-import DotLoader from '~/components/DotLoader';
+import { DotLoader } from '~/components2/Loaders';
 
 interface Props extends RouteComponentProps {
   showLoadingIndicator?: boolean;

--- a/src/pages/Reports/components/BaseMap/BaseMap.tsx
+++ b/src/pages/Reports/components/BaseMap/BaseMap.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import config from '~/pages/Reports/config';
-import BigLoader from '~/components/BigLoader';
+import { BigLoader } from '~/components2/Loaders/';
 import Map from '~/components2/Map';
 
 const MB_STYLE_URL = `${config.reports.overviewMap.style}${

--- a/src/pages/Reports/components/LinkLayer/linkService.tsx
+++ b/src/pages/Reports/components/LinkLayer/linkService.tsx
@@ -13,12 +13,7 @@ import {
 
 const log = debug('fmc:reports:LinkLayer');
 
-const enum NODE_TYPE {
-  PLANNING = 'PLANNING',
-  REPORT = 'REPORT',
-  // some status we do not care about
-  UNHANDLED = 'UHANDLED',
-}
+type NODE_TYPE = 'PLANNING' | 'REPORT' | 'UNHANDLED';
 
 type Node = {
   readonly coordinates: [number, number];
@@ -73,12 +68,12 @@ function getNode(report: Omit<Report, 'origin' | 'plannings'>): Node {
 
 function getNodeType(reportStatus: Status): NODE_TYPE {
   if (STATUS_REPORT.includes(reportStatus)) {
-    return NODE_TYPE.REPORT;
+    return 'REPORT';
   }
   if (STATUS_PLANNING.includes(reportStatus)) {
-    return NODE_TYPE.PLANNING;
+    return 'PLANNING';
   }
-  return NODE_TYPE.UNHANDLED;
+  return 'UNHANDLED';
 }
 
 function getReportLinks(selectedReport: Report) {


### PR DESCRIPTION
The projects map doesn't show project pin markers while data about projects is loaded from the backend. This adds an animation that is displayed while attempting to load data.

Closes #745 

## How Has This Been Tested?

- visit projects map at /planungen
- observe a loading animation visible in the center of the screen until the projects have been completely loaded

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
