### PR TITLE
Hotfix: encode uploaded attachment's file name

### DIFF
--- a/src/apps/Gastro/api.ts
+++ b/src/apps/Gastro/api.ts
@@ -152,7 +152,7 @@ const uploadCertificate = async (
   district: DistrictConfig
 ) => {
   const formData = new FormData();
-  const fileName = registrationData.certificate.name;
+  const fileName = encodeURI(registrationData.certificate.name);
 
   // For some reason this call sometimes, but not always throws an error:
   //   TS2554: Expected 2 arguments, but got 3.

--- a/src/apps/Gastro/components/RegistrationForm/SectionCertificate.tsx
+++ b/src/apps/Gastro/components/RegistrationForm/SectionCertificate.tsx
@@ -82,6 +82,7 @@ const SectionCertificate = ({
         setUploadError(
           'Das Hochladen Ihrer Gewerbeanmeldung / Ihres Vereinsregisters ist fehlgeschlagen. Bitte prüfen Sie Ihre Internetverbindung und versuchen es erneut.'
         );
+        throw e;
       }
       setSubmittingCertificate(false);
     };


### PR DESCRIPTION
Closes #859