### PR TITLE
Release: 2021/06/14-2

### DIFF
--- a/src/config/berlin/xhain.ts
+++ b/src/config/berlin/xhain.ts
@@ -100,7 +100,7 @@ const xhain: DistrictConfig = {
           status: 'closed',
         },
         {
-          street: 'Böckstraße',
+          street: 'Böckhstraße',
           kiez: 'Graefekiez',
           region: 'Kreuzberg',
           status: 'open',


### PR DESCRIPTION
Fix name of Böckhstraße, release in sync with `fixmyplatform` https://github.com/FixMyBerlin/fixmy.platform/pull/585