### PR TITLE
Disable KatasterKI integration tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -10,9 +10,18 @@
     "openMode": 0
   },
   "whitelist": {
-    "default": ["Map", "Reports", "KatasterKI"],
-    "aachen": ["Reports"],
-    "berlin": ["Map", "Reports", "KatasterKI", "Analysis"],
+    "default": [
+      "Map",
+      "Reports"
+    ],
+    "aachen": [
+      "Reports"
+    ],
+    "berlin": [
+      "Map",
+      "Reports",
+      "Analysis"
+    ],
     "eichwalde": []
   }
 }


### PR DESCRIPTION
While the subjective safety survey is still online and operational at [https://fixmyberlin.de/strassencheck](https://fixmyberlin.de/strassencheck), the integration tests for that app are disabled here to save on time in the CI.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
