### PR TITLE
Add edit button to reports detail panel

### DIFF
--- a/src/pages/Reports/pages/OverviewMap/components/ReportDetails/Header.js
+++ b/src/pages/Reports/pages/OverviewMap/components/ReportDetails/Header.js
@@ -1,11 +1,15 @@
+import debug from 'debug';
 import React from 'react';
 import styled from 'styled-components';
 
+import { AnchorButton } from '~/components2/Button';
+import config from '~/config';
 import BikestandsIcon from '~/images/reports/bikestands-icon.svg';
 import { getReportStatusCaption } from '~/pages/Reports/apiservice';
 import ReportPin from '~/pages/Reports/components/ReportPin';
-import config from '~/pages/Reports/config';
 import Heading from '~/pages/Reports/pages/SubmitReport/components/Heading';
+
+const log = debug('fmc:reports:overviewmap:details:header');
 
 const HeadlineSection = styled.div`
   display: flex;
@@ -41,7 +45,16 @@ const DetailsHeading = styled(Heading)`
   font-size: 1.4em;
 `;
 
-const DetailsHeader = ({ details: { number }, status }) => (
+const EditButton = styled(AnchorButton)`
+  height: 2em;
+`;
+
+const getEditURL = (id) => {
+  const adminBaseURL = config.apiUrl.replace('/api', '/admin');
+  return `${adminBaseURL}/reports/bikestands/${id}/change/`;
+};
+
+const DetailsHeader = ({ details: { number }, status, id }) => (
   <>
     <HeadlineSection data-cy="reports-detail-title">
       <DetailsHeading alignLeft>
@@ -64,6 +77,14 @@ const DetailsHeader = ({ details: { number }, status }) => (
       </StatusIndicator>
       <ReportPin status={status} />
     </StatusIndicatorWrapper>
+
+    {process.env.NODE_ENV !== 'production' && (
+      <StatusIndicatorWrapper>
+        <EditButton flat target="_blank" href={getEditURL(id)}>
+          Edit
+        </EditButton>
+      </StatusIndicatorWrapper>
+    )}
   </>
 );
 

--- a/src/pages/Reports/pages/OverviewMap/components/ReportDetails/Header.js
+++ b/src/pages/Reports/pages/OverviewMap/components/ReportDetails/Header.js
@@ -1,4 +1,3 @@
-import debug from 'debug';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -8,8 +7,6 @@ import BikestandsIcon from '~/images/reports/bikestands-icon.svg';
 import { getReportStatusCaption } from '~/pages/Reports/apiservice';
 import ReportPin from '~/pages/Reports/components/ReportPin';
 import Heading from '~/pages/Reports/pages/SubmitReport/components/Heading';
-
-const log = debug('fmc:reports:overviewmap:details:header');
 
 const HeadlineSection = styled.div`
   display: flex;
@@ -78,7 +75,7 @@ const DetailsHeader = ({ details: { number }, status, id }) => (
       <ReportPin status={status} />
     </StatusIndicatorWrapper>
 
-    {process.env.NODE_ENV !== 'production' && (
+    {config.debug === true && (
       <StatusIndicatorWrapper>
         <EditButton flat target="_blank" href={getEditURL(id)}>
           Edit


### PR DESCRIPTION
This allows opening a report in the Django admin web view.

Only shows for `NODE_ENV !== 'production'`

## How Has This Been Tested?

- run with `npm start`, open reports overview map, click any report and find an "edit" button in the right hand panel
- run with `NODE_ENV=production npm start` - don't see any edit button

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
