### PR TITLE
Add React Helmet & noindex meta tag to privacy/imprint markdown page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "react-copy-to-clipboard": "^5.0.2",
         "react-dom": "^16.14.0",
         "react-feather": "^2.0.3",
+        "react-helmet": "^6.1.0",
         "react-intersection-observer": "^8.31.0",
         "react-intl": "^5.4.7",
         "react-markdown": "^4.3.1",
@@ -38143,6 +38144,20 @@
         "react": "^16.8.6"
       }
     },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
     "node_modules/react-helmet-async": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.7.tgz",
@@ -38171,6 +38186,19 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "node_modules/react-helmet/node_modules/react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "node_modules/react-helmet/node_modules/react-side-effect": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0"
+      }
     },
     "node_modules/react-hotkeys": {
       "version": "2.0.0",
@@ -77421,6 +77449,30 @@
       "integrity": "sha512-XVjtxIyMxb2RFlqC2APoB/IZvXKDW9uLN1c264XEeZNYe8jIxjQVQpeTo3nxtHiLTgMfgf0ZYxJC6HwmY8+9BA==",
       "requires": {
         "prop-types": "^15.7.2"
+      }
+    },
+    "react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "dependencies": {
+        "react-fast-compare": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+          "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+        },
+        "react-side-effect": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
+          "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
+          "requires": {}
+        }
       }
     },
     "react-helmet-async": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^16.14.0",
     "react-feather": "^2.0.3",
+    "react-helmet": "^6.1.0",
     "react-intersection-observer": "^8.31.0",
     "react-intl": "^5.4.7",
     "react-markdown": "^4.3.1",

--- a/public/markdown/imprint.md
+++ b/public/markdown/imprint.md
@@ -1,3 +1,5 @@
+<!-- This page contains a noindex meta tag, see src/pages/Markdown/index.js  -->
+
 # Impressum
 
 FixMyCity GmbH<br />

--- a/public/markdown/privacy.md
+++ b/public/markdown/privacy.md
@@ -1,3 +1,5 @@
+<!-- This page contains a noindex meta tag, see src/pages/Markdown/index.js  -->
+
 # Datenschutzerklärung
 
 Mit der folgenden Datenschutzerklärung möchten wir Sie darüber aufklären, welche Arten Ihrer personenbezogenen Daten (nachfolgend auch kurz als "Daten“ bezeichnet) wir zu welchen Zwecken und in welchem Umfang verarbeiten. Die Datenschutzerklärung gilt für alle von uns durchgeführten Verarbeitungen personenbezogener Daten, sowohl im Rahmen der Erbringung unserer Leistungen als auch insbesondere auf unseren Webseiten, in mobilen Applikationen sowie innerhalb externer Onlinepräsenzen, wie z.B. unserer Social-Media-Profile (nachfolgend zusammenfassend bezeichnet als "Onlineangebot“).

--- a/src/pages/Markdown/index.js
+++ b/src/pages/Markdown/index.js
@@ -7,7 +7,13 @@ import MarkdownContent from '~/pages/Markdown/components/MarkdownContent';
 
 class MarkdownPage extends PureComponent {
   // Hardcode page names which should include noindex meta tag
-  noindexPages = ['imprint', 'privacy'];
+  noindexPages = [
+    'imprint',
+    'privacy',
+    'aachen-imprint',
+    'aachen-privacy',
+    'nomatch',
+  ];
 
   constructor(props) {
     super(props);

--- a/src/pages/Markdown/index.js
+++ b/src/pages/Markdown/index.js
@@ -1,10 +1,22 @@
 import ky from 'ky';
 import React, { PureComponent } from 'react';
+import { Helmet } from 'react-helmet';
 
 import ContentPageWrapper from '~/components/ContentPageWrapper';
 import MarkdownContent from '~/pages/Markdown/components/MarkdownContent';
 
 class MarkdownPage extends PureComponent {
+  static addNoindexMeta() {
+    return (
+      <Helmet>
+        <meta name="robots" content="noindex" />
+      </Helmet>
+    );
+  }
+
+  // Hardcode page names which should include noindex meta tag
+  noindexPages = ['imprint', 'privacy'];
+
   constructor(props) {
     super(props);
     this.state = {
@@ -29,8 +41,14 @@ class MarkdownPage extends PureComponent {
   }
 
   render() {
+    let helmet;
+    if (this.noindexPages.includes(this.props.page)) {
+      helmet = MarkdownPage.addNoindexMeta();
+    }
+
     return (
       <ContentPageWrapper>
+        {helmet}
         <MarkdownContent content={this.state.content} />
       </ContentPageWrapper>
     );

--- a/src/pages/Markdown/index.js
+++ b/src/pages/Markdown/index.js
@@ -6,14 +6,6 @@ import ContentPageWrapper from '~/components/ContentPageWrapper';
 import MarkdownContent from '~/pages/Markdown/components/MarkdownContent';
 
 class MarkdownPage extends PureComponent {
-  static addNoindexMeta() {
-    return (
-      <Helmet>
-        <meta name="robots" content="noindex" />
-      </Helmet>
-    );
-  }
-
   // Hardcode page names which should include noindex meta tag
   noindexPages = ['imprint', 'privacy'];
 
@@ -41,14 +33,13 @@ class MarkdownPage extends PureComponent {
   }
 
   render() {
-    let helmet;
-    if (this.noindexPages.includes(this.props.page)) {
-      helmet = MarkdownPage.addNoindexMeta();
-    }
-
     return (
       <ContentPageWrapper>
-        {helmet}
+        {this.noindexPages.includes(this.props.page) && (
+          <Helmet>
+            <meta name="robots" content="noindex" />
+          </Helmet>
+        )}
         <MarkdownContent content={this.state.content} />
       </ContentPageWrapper>
     );


### PR DESCRIPTION
## Changes
* New dependency: React Helmet
* Used Helmet for adding <meta> Tag for `noindex`
* Hardcoded list of pages which should include `noindex`

## How Has This Been Tested?

Imprint & Privacy contains `<meta>` Tag, API or Press for example not. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works


After this is reviewed, the corresponding Task in Project board should be deleted: https://github.com/FixMyBerlin/fixmy.platform/projects/5