### PR TITLE
Introduce launch.json for VSCode for debugging purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ yarn.lock
 localtest
 
 # IDEs
-.vscode
 .idea/
 /coverage/
 public/lab/assets/fonts/franklin_gothic_fs*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}"
+        },
+        {
+            "type": "firefox",
+            "request": "launch",
+            "reAttach": true,
+            "name": "Launch Firefox",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}"
+        },
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Did you encounter an issue that you would like to tell us about? Would you like
 to add to this project yourself? Go ahead and check the
 [contribution guide](CONTRIBUTING.md).
 
+We use [VSCode](https://code.visualstudio.com/) for as an IDE. It is recommended to do so.
+
 ## Installation
 
 We recommend using [nvm](https://github.com/nvm-sh/nvm) or [asdf](https://asdf-vm.com/) to run this project with the Node version specified in `.nvmrc` and [`.tool-versions`](.tool-versions).
@@ -76,6 +78,10 @@ Each branch gets automatically deployed on netlify:
 
 - https://fixmyberlin-app.netlify.app/ [master]
 - https://develop--fixmyberlin-app.netlify.app/ [develop]
+
+## Debugging
+
+In VSCode you can use the integrated debugging profiles for Chrome & Firefox to easily debug your code directly in `Run and Debug` section.
 
 ### Embed Mode
 


### PR DESCRIPTION
Since we decided on VSCode as standard I propose to introduce and use the profiles for launching debugging sessions directly in VSCode. For beginner this is also easier to start. Instead every developer creating this file for its own use, I would add this to Git.
I've added also some references in the main README. 