### PR TITLE
Remove querystring dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,8 +53,6 @@
         "lodash.isequal": "^4.5.0",
         "mapbox-gl": "^1.11.1",
         "prop-types": "^15.7.2",
-        "qs": "^6.9.4",
-        "query-string": "^6.13.8",
         "rc-slider": "^9.6.2",
         "react": "^16.14.0",
         "react-autosize-textarea": "^7.1.0",
@@ -36908,22 +36906,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/query-string": {
-      "version": "6.13.8",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.8.tgz",
-      "integrity": "sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==",
-      "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -41079,14 +41061,6 @@
         "node": "*"
       }
     },
-    "node_modules/split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -41450,14 +41424,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
-    },
-    "node_modules/strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -76462,16 +76428,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
       "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
-    "query-string": {
-      "version": "6.13.8",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.8.tgz",
-      "integrity": "sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      }
-    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -79786,11 +79742,6 @@
         "through": "2"
       }
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -80064,11 +80015,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string_decoder": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "mapbox-gl": "^1.11.1",
     "prop-types": "^15.7.2",
     "qs": "^6.9.4",
-    "query-string": "^6.13.8",
     "rc-slider": "^9.6.2",
     "react": "^16.14.0",
     "react-autosize-textarea": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "lodash.isequal": "^4.5.0",
     "mapbox-gl": "^1.11.1",
     "prop-types": "^15.7.2",
-    "qs": "^6.9.4",
     "rc-slider": "^9.6.2",
     "react": "^16.14.0",
     "react-autosize-textarea": "^7.1.0",

--- a/src/apps/Map/MapState.ts
+++ b/src/apps/Map/MapState.ts
@@ -1,5 +1,4 @@
 import ky from 'ky';
-import qs from 'qs';
 import { match, matchPath } from 'react-router-dom';
 import { Action, Dispatch } from 'redux';
 import { ThunkAction } from 'redux-thunk';
@@ -176,7 +175,7 @@ export const updateHistory = (path: string) => (dispatch: Dispatch) => {
 
 export const detectEmbedMode = (location: Location) => (dispatch: Dispatch) => {
   const isEmbedMode =
-    !!qs.parse(location.search, { ignoreQueryPrefix: true }).embed ||
+    !!new URLSearchParams(location.search).has('embed') ||
     window.location.host === 'embed.fixmyberlin.de';
 
   const action: UpdateHistory = {

--- a/src/pages/KatasterKI/pages/Landing.js
+++ b/src/pages/KatasterKI/pages/Landing.js
@@ -1,4 +1,3 @@
-import queryString from 'query-string';
 import React from 'react';
 import { Redirect, Link, matchPath } from 'react-router-dom';
 import styled from 'styled-components';
@@ -218,8 +217,7 @@ const TOC = () => (
  * agreed to and the user is routed directly into the survey.
  */
 const checkEmbeddedParam = (value) => {
-  const params = queryString.parse(value);
-  if (Object.keys(params).indexOf('embedded') > -1) {
+  if (new URLSearchParams(value).has('embedded')) {
     Store.dispatch(setEmbedded(true));
     return true;
   }

--- a/src/pages/User/pages/Verify.js
+++ b/src/pages/User/pages/Verify.js
@@ -1,5 +1,4 @@
 import ky from 'ky';
-import qs from 'qs';
 import React, { useEffect, useState } from 'react';
 import { Link, withRouter } from 'react-router-dom';
 import styled from 'styled-components';
@@ -44,9 +43,7 @@ const UserVerify = ({ match, location }) => {
   useEffect(() => {
     const verifyUser = async () => {
       const { uid, token } = match.params;
-      const { newsletter } = qs.parse(location.search, {
-        ignoreQueryPrefix: true,
-      });
+      const newsletter = new URLSearchParams(location.search).get('newsletter');
       const signupNewsletter = newsletter === 'yes';
 
       try {


### PR DESCRIPTION
This removes the dependencies `qs` and `query-string`. They have been replaced by native [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams).

Closes #728 

## How Has This Been Tested?

This  potentially breaks the URLs with search parameters like `?embed` , `?embedded` and `?newsletter=yes`. In the map view, user registration success view and strassencheck view. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
