### PR TITLE
Silence eslint warnings in development

### DIFF
--- a/webpack/webpack.config.dev.js
+++ b/webpack/webpack.config.dev.js
@@ -45,7 +45,7 @@ module.exports = merge(common, {
         loader: 'eslint-loader',
         options: {
           emitWarning: true,
-          cache: true,
+          cache: false,
         },
       },
       {


### PR DESCRIPTION
Henri, I think we should merge this, right?

---

`"react/require-default-props": 0` was not enough, apparently

Co-Authored-By: Henri <6567206+ohrie@users.noreply.github.com>
