### PR TITLE
WebglMap: Activate hash-urls [skip ci]

### DIFF
--- a/src/apps/Map/components/WebglMap/WebglMap.tsx
+++ b/src/apps/Map/components/WebglMap/WebglMap.tsx
@@ -95,6 +95,7 @@ class Map extends PureComponent<Props, State> {
       container: this.root,
       style: MB_STYLE_URL,
       bounds: config.apps.map.bounds,
+      hash: true,
     });
     const nav = new MapboxGL.NavigationControl({ showCompass: false });
     this.map.addControl(nav, 'bottom-left');


### PR DESCRIPTION
Introduces URLs like 
> http://localhost:8080/zustand#14.8/52.48902/13.37598

Docs at https://docs.mapbox.com/mapbox-gl-js/api/map/

Allows to deeplink to a location on the map. It does not sync the filter and hbi<>planning state, yet.
