### PR TITLE
Xhain: Fix last name & update official status

### DIFF
--- a/src/apps/Gastro/pages/Landing/xhain.tsx
+++ b/src/apps/Gastro/pages/Landing/xhain.tsx
@@ -266,7 +266,7 @@ const XhainLanding = ({ district }) => (
     <Section>
       <QuoteSection>
         <Img
-          alt="Portrait Monika Hermann"
+          alt="Portrait Monika Herrmann"
           src={MayorImg}
           srcSet={`${MayorImg2} 2x, ${MayorImg3} 3x`}
         />
@@ -278,7 +278,7 @@ const XhainLanding = ({ district }) => (
         </BlockQuote>
         <SourcePerson>Monika Herrmann</SourcePerson>
         <SourceFunction>
-          Bezirksbürgermeisterin von Friedrichshain-Kreuzberg
+          Ex-Bezirksbürgermeisterin von Friedrichshain-Kreuzberg
         </SourceFunction>
       </QuoteSection>
     </Section>


### PR DESCRIPTION
"HerRmann"

She is no longer the mayor of Friedrichshain-Kreuzberg and uses "Ex-" in front of her former job title for herself now.