### PR TITLE
eslint config: Remove import order rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -96,7 +96,8 @@
 
     "react/function-component-definition": [
       1,
-      { "namedComponents": "arrow-function",
+      {
+        "namedComponents": "arrow-function",
         "unnamedComponents": "arrow-function"
       }
     ],
@@ -117,28 +118,7 @@
     // auto completion for imports and prevent inconsistent naming conventions
     // across modules.
     "import/prefer-default-export": ["off"],
-
-    // Import order is fixed for easier scanning of imports and to prevent
-    // file changes from changed import order.
-    //
-    // This configuration separates sources specified in `groups` with newlines
-    // and sorts moves imports from `~` into the `internal` group.
-    "import/order": [
-      "warn",
-      {
-        "alphabetize": { "order": "asc" },
-        "groups": [
-          "builtin",
-          "external",
-          ["sibling", "parent", "internal"],
-          "index"
-        ],
-        "newlines-between": "always",
-        "pathGroups": [
-          { "pattern": "~/**", "group": "internal", "position": "before" }
-        ]
-      }
-    ]
+    "import/order": "off" // Turned off; we use VSCode's sort "Organize Imports" instead
   },
 
   "env": {


### PR DESCRIPTION
I suggest we remove this rule and instead rely on VS Codes "Organize Imports" which can be done on save https://eshlox.net/2019/12/02/vscode-automatically-organize-typescript-imports/
