### PR TITLE
Remove popupbikelanes map and route

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,4 +1,3 @@
-
 # Radbuegel XHain
 /radbuegel /meldungen/radbuegel/friedrichshain-kreuzberg/karte 302
 /meldungen/radbuegel/friedrichshain-kreuzberg/neu/1 /meldungen/radbuegel/friedrichshain-kreuzberg/karte 302
@@ -6,7 +5,10 @@
 
 # Spielstraßen
 /friedrichshain-kreuzberg/spielstra%C3%9Fen /friedrichshain-kreuzberg/spielstrassen 301
- 
+
+# Removed content
+/popupbikelanes /planungen:splat 302
+
 # Legacy Plannings Redirects
 /planungen/2725/* /planungen/4/:splat 301
 /planungen/2866/* /planungen/6/:splat 301

--- a/src/apps/Map/MapState.ts
+++ b/src/apps/Map/MapState.ts
@@ -39,7 +39,7 @@ export const SET_HBI_DATA = 'Map/MapState/SET_HBI_DATA';
 const SET_HBI_DATA_FETCH_STATE = 'Map/MapState/SET_HBI_DATA_FETCH_STATE';
 
 // parsed from the first path segment of the url
-type MapView = 'zustand' | 'planungen' | 'popupbikelanes';
+type MapView = 'zustand' | 'planungen';
 
 // todo: define this based on fixmy.platform serializer & model
 type ProjectFromMapbox = any;

--- a/src/apps/Map/components/ProjectMarkers.js
+++ b/src/apps/Map/components/ProjectMarkers.js
@@ -52,23 +52,20 @@ class ProjectMarkers extends PureComponent {
     const TEMPORARY_PLANNINGS_PHASE_INDEX = 4;
     const phaseIndex = phasesOrder.indexOf(marker.phase);
 
-    if (this.props.onlyPopupbikelanes) {
-      if (marker.phase !== 'inactive') return false;
-    } else {
-      // Don't show markers whose phase is not active in filterPlannings
-      if (
-        !this.props.filterPlannings[phaseIndex] &&
-        phaseIndex !== TEMPORARY_PLANNINGS_PHASE_INDEX
-      ) {
-        return false;
-      }
+    // Don't show markers whose phase is not active in filterPlannings
+    if (
+      !this.props.filterPlannings[phaseIndex] &&
+      phaseIndex !== TEMPORARY_PLANNINGS_PHASE_INDEX
+    ) {
+      return false;
+    }
 
-      // Don't show temporary plannings if ready phase is disabled
-      if (
-        !this.props.filterPlannings[3] &&
-        phaseIndex === TEMPORARY_PLANNINGS_PHASE_INDEX
-      )
-        return false;
+    // Don't show temporary plannings if ready phase is disabled
+    if (
+      !this.props.filterPlannings[3] &&
+      phaseIndex === TEMPORARY_PLANNINGS_PHASE_INDEX
+    ) {
+      return false;
     }
 
     if (marker.center == null) {

--- a/src/apps/Map/components/WebglMap/WebglMap.tsx
+++ b/src/apps/Map/components/WebglMap/WebglMap.tsx
@@ -23,7 +23,6 @@ import {
   intersectionLayers,
   parseUrlOptions,
   setPlanningLegendFilter,
-  setPopupLanesFilter,
   standardLayersWithOverlay,
 } from '~/apps/Map/map-utils';
 import resetMap from '~/apps/Map/reset';
@@ -140,10 +139,7 @@ class Map extends PureComponent<Props, State> {
       resetMap({ zoom: this.map.getZoom() });
     }
 
-    if (
-      this.props.activeView === 'planungen' ||
-      this.props.activeView === 'popupbikelanes'
-    ) {
+    if (this.props.activeView === 'planungen') {
       Store.dispatch<any>(MapActions.loadPlanningData());
     }
 
@@ -228,11 +224,7 @@ class Map extends PureComponent<Props, State> {
         } else {
           setCursorNone();
         }
-      } else if (
-        features.length > 0 &&
-        (this.props.activeView === 'planungen' ||
-          this.props.activeView === 'popupbikelanes')
-      ) {
+      } else if (features.length > 0 && this.props.activeView === 'planungen') {
         if (projectsTarget === features[0].layer.id) {
           setCursorPointer();
         } else {
@@ -244,7 +236,7 @@ class Map extends PureComponent<Props, State> {
 
   updateLayers = () => {
     const isZustand = this.props.activeView === 'zustand';
-    let isPlanungen = this.props.activeView === 'planungen';
+    const isPlanungen = this.props.activeView === 'planungen';
 
     const hbiLayers = config.apps.map.layers.hbi;
     const projectsLayers = config.apps.map.layers.projects;
@@ -253,14 +245,7 @@ class Map extends PureComponent<Props, State> {
       toggleVisibleHbiLines(this.map, this.props.filterHbi);
     }
 
-    if (this.props.activeView === 'popupbikelanes') {
-      // Make sure that planning layers are set visible in Mapbox to be
-      // able to see popup bike lane geometries
-      isPlanungen = true;
-      setPopupLanesFilter(this.map);
-    } else {
-      setPlanningLegendFilter(this.map, this.props.filterPlannings);
-    }
+    setPlanningLegendFilter(this.map, this.props.filterPlannings);
 
     // project layers
     // toggleLayer(this.map, 'fmb-projects', false);
@@ -397,9 +382,7 @@ class Map extends PureComponent<Props, State> {
 
   render() {
     const markerData = this.props.planningData?.results;
-    const markersVisible =
-      this.props.activeView === 'planungen' ||
-      this.props.activeView === 'popupbikelanes';
+    const markersVisible = this.props.activeView === 'planungen';
 
     const isLoading =
       this.state.loading || this.props.planningDataFetchState === 'pending';
@@ -419,7 +402,6 @@ class Map extends PureComponent<Props, State> {
           active={markersVisible}
           onClick={this.handleMarkerClick}
           filterPlannings={this.props.filterPlannings}
-          onlyPopupbikelanes={this.props.activeView === 'popupbikelanes'}
         />
       </StyledMap>
     );

--- a/src/apps/Map/index.tsx
+++ b/src/apps/Map/index.tsx
@@ -160,19 +160,6 @@ const MapView = ({
             />
           )}
         />
-        <Route
-          exact
-          path={config.routes.map.popupDetail}
-          render={({ match }) => (
-            <ProjectDetail
-              apiEndpoint="projects"
-              onCloseRoute={config.routes.map.popupIndex}
-              activeView={activeLayer}
-              token={token}
-              match={match}
-            />
-          )}
-        />
       </MapWrapper>
     </Wrapper>
   );

--- a/src/apps/Map/map-utils.ts
+++ b/src/apps/Map/map-utils.ts
@@ -136,27 +136,6 @@ export function setPlanningLegendFilter(
 }
 
 /**
- * Show all popup bike lanes from the projects layer
- *
- * @param {MapboxGL instance} map
- */
-export function setPopupLanesFilter(map: mapboxgl.Map) {
-  const filter = ['==', 'inactive', ['get', 'phase']];
-  map.setFilter(config.apps.map.layers.projects.center, filter);
-  map.setFilter(config.apps.map.layers.projects.overlayLine, filter);
-  map.setFilter(config.apps.map.layers.projects.side0, [
-    'all',
-    sideFilter0,
-    filter,
-  ]);
-  map.setFilter(config.apps.map.layers.projects.side1, [
-    'all',
-    sideFilter1,
-    filter,
-  ]);
-}
-
-/**
  * Return a Mapbox expression to access the HBI values embedded in Mapbox
  *
  * @param {*} sideKey which side's HBI value to retrieve (layer prefix)

--- a/src/apps/Map/tests/map-utils.unit.test.js
+++ b/src/apps/Map/tests/map-utils.unit.test.js
@@ -3,7 +3,6 @@ import config from '~/config';
 import * as utils from '../map-utils';
 import mapboxHBIFilter from './fixtures/mapboxHBIFilter.json';
 import mapBoxPlanningsFilter from './fixtures/mapboxPlanningsFilter.json';
-import mapboxPopupFilter from './fixtures/mapboxPopupFilter.json';
 
 const view = {
   zoom: true,
@@ -140,14 +139,6 @@ describe('setPlanningLegendFilter()', () => {
     };
     utils.setPlanningLegendFilter(map, [true, true, false, true]);
     expect(map.setFilter.mock.calls).toEqual(mapBoxPlanningsFilter);
-  });
-});
-
-describe('setPopupLanesFilter()', () => {
-  it('assembles correct rules for showing only popup bike lanes', () => {
-    const map = { setFilter: jest.fn() };
-    utils.setPopupLanesFilter(map);
-    expect(map.setFilter.mock.calls).toEqual(mapboxPopupFilter);
   });
 });
 

--- a/src/components/CloseButton.js
+++ b/src/components/CloseButton.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-
 import config from '~/config';
 
 const CloseButton = styled.button`

--- a/src/config/default/routes.ts
+++ b/src/config/default/routes.ts
@@ -5,8 +5,6 @@ interface RouteConfig {
     projectsDetail: string;
     hbiIndex: string;
     hbiDetail: string;
-    popupIndex: string;
-    popupDetail: string;
   };
   analysis?: string;
   reports?: {

--- a/src/config/default/routes.ts
+++ b/src/config/default/routes.ts
@@ -18,7 +18,6 @@ interface RouteConfig {
   spielstrassen?: {
     [page: string]: string;
   };
-  popupbikelanes?: string;
   research?: {
     [page: string]: string;
   };
@@ -39,8 +38,6 @@ const routes: RouteConfig = {
     hbiDetail: '/zustand/:id/:name?',
     projectsIndex: '/planungen',
     projectsDetail: '/planungen/:id/:name?',
-    popupIndex: '/popupbikelanes',
-    popupDetail: '/popupbikelanes/:id/:name?',
   },
   reports: {
     temporarily_forward_from_this_to_index: '/meldungen',
@@ -66,7 +63,6 @@ const routes: RouteConfig = {
     register: '/friedrichshain-kreuzberg/spielstrassen/:slug',
     thanks: '/friedrichshain-kreuzberg/spielstrassen/:slug/danke',
   },
-  popupbikelanes: '/popupbikelanes',
   signup: '/registrieren',
   login: '/anmelden',
   forgotPassword: '/passwort-vergessen',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -119,9 +119,6 @@ const Routes = ({ token }) => (
     {config.routes.map?.projectsIndex != null && (
       <Route path={config.routes.map.projectsIndex} component={MapView} />
     )}
-    {config.routes.map?.popupIndex != null && (
-      <Route path={config.routes.map.popupIndex} component={MapView} />
-    )}
 
     {/* reports page */}
     {config.routes.reports != null && (


### PR DESCRIPTION
The data is still in use on the planning map, but the separate view is not needed anymore.