### PR TITLE
Fix API URL of Netlify redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[redirects]]
     from = "/api/v1/*"
-    to = "https://api.fixmyberlin.de/api/:splat"
+    to = "https://fixmyberlin.de/api/:splat"
     status = 200
     force = true
     [redirects.headers]


### PR DESCRIPTION
## Problem
The url `https://api.fixmyberlin.de/api/` is not existing (anymore). Therefore the HTTP headers defined in `netlify.toml` are not working anymore. Therefore CORS leads to problems.