### PR TITLE
display the legend by default for desktop clients

### DIFF
--- a/src/apps/Map/index.tsx
+++ b/src/apps/Map/index.tsx
@@ -119,7 +119,7 @@ const MapView = ({
     Store.dispatch(MapActions.setView(view));
   };
 
-  // only show legend on startup when on desktop
+  // only show legend on startup for desktop clients
   const [showLegend, setShowLegend] = useState(isDesktopView);
 
   useURLParams();

--- a/src/apps/Map/index.tsx
+++ b/src/apps/Map/index.tsx
@@ -119,8 +119,8 @@ const MapView = ({
     Store.dispatch(MapActions.setView(view));
   };
 
-  // Do not show legend on startup
-  const [showLegend, setShowLegend] = useState(false);
+  // only show legend on startup when on desktop
+  const [showLegend, setShowLegend] = useState(isDesktopView);
 
   useURLParams();
 


### PR DESCRIPTION
This PR addresses and Closes #983 

## How Has This Been Tested?
With the mobile mode of Firefox's webdeveloper-tools. Not tested on an actual phone. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
