### PR TITLE
2022-05-15 Remove phone support for XHain Terrassen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: Node.js CI
 
 on:
   push:
+    paths-ignore:
+      - '**.md'
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Read node version from .nvmrc
         id: nvmrc
@@ -49,7 +49,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Read node version from .nvmrc
         id: nvmrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         id: nvmrc
         uses: browniebroke/read-nvmrc-action@v1
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '${{ steps.nvmrc.outputs.node_version }}'
 
@@ -34,7 +34,7 @@ jobs:
 
       - run: npm ci
       - run: npm run test:coverage
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           directory: coverage
@@ -55,11 +55,11 @@ jobs:
         id: nvmrc
         uses: browniebroke/read-nvmrc-action@v1
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '${{ steps.nvmrc.outputs.node_version }}'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Preload reports endpoints
         run: curl https://fixmyberlin-staging.netlify.app/api/aachen/next/reports https://fixmyaachen-staging.netlify.app/api/next/reports --retry 3 > /dev/null &
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Read node version from .nvmrc
         id: nvmrc

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,12 +24,12 @@ jobs:
         id: nvmrc
         uses: browniebroke/read-nvmrc-action@v1
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '${{ steps.nvmrc.outputs.node_version }}'
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -57,7 +57,7 @@ jobs:
           REGION: ${{ matrix.region }}
           CYPRESS_REGION: ${{ matrix.region }}
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           directory: coverage
           flags: e2etests

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,6 @@
     "editorconfig.editorconfig",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "jpoissonnier.vscode-styled-components"
+    "styled-components.vscode-styled-components"
   ]
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,7 +30,7 @@
 
 [[redirects]]
     from = "/api/aachen/next/*"
-    to = "https://fixmyaachen-staging.herokuapp.com/api/:splat"
+    to = "https://radbuegel-aachen-staging.tiummk647p9vk.eu-central-1.cs.amazonlightsail.com/api/:splat"
     status = 200
     force = true
     [redirects.headers]

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,7 +30,7 @@
 
 [[redirects]]
     from = "/api/aachen/next/*"
-    to = "https://radbuegel-aachen-staging.tiummk647p9vk.eu-central-1.cs.amazonlightsail.com/api/:splat"
+    to = "https://api-staging.radbuegel-aachen.de/api/:splat"
     status = 200
     force = true
     [redirects.headers]

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@
 
 [[redirects]]
     from = "/api/next/*"
-    to = "https://fixmyplatform-develop.herokuapp.com/api/:splat"
+    to = "https://api-staging.fixmyberlin.de/api/:splat"
     status = 200
     force = true
     [redirects.headers]

--- a/package-lock.json
+++ b/package-lock.json
@@ -17980,9 +17980,9 @@
       }
     },
     "node_modules/portfinder/node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
@@ -37619,9 +37619,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
           "dev": true,
           "requires": {
             "lodash": "^4.17.14"

--- a/src/apps/Gastro/components/HotlineNotice.tsx
+++ b/src/apps/Gastro/components/HotlineNotice.tsx
@@ -37,13 +37,6 @@ const HotlineNotice = () => {
           </a>{' '}
           werden die häufigsten Fragen beantwortet.
         </p>
-        <p>
-          Bitte nutzen Sie auch unsere telefonische Beratung:
-          <br />
-          Mittwoch von 11:00 - 15:00 Uhr
-          <br />
-          Freitag von 13:00 - 17:00 Uhr
-        </p>
       </CardContent>
       <CardActions>
         <Button
@@ -57,7 +50,7 @@ const HotlineNotice = () => {
       </CardActions>
       <CardContent>
         <Typography>
-          Alternativ kontaktieren Sie{' '}
+          Kontaktieren Sie{' '}
           <Link href="mailto:gastro@ba-fk.berlin.de">
             gastro@ba-fk.berlin.de
           </Link>{' '}


### PR DESCRIPTION
# Don't release before 2022-05-15 !

This updates minor versions of some packages, updates configuration (also lightsail migration) and removes the phone support text of XHain Terrassen 