### PR TITLE
Introduce husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,75 @@
+#!/usr/bin/sh
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
+export NVM_DIR="$HOME/.nvm/nvm.sh"
+. "$(dirname $NVM_DIR)/nvm.sh"
+
+export NVM_DIR="$HOME/.nvm"
+a=$(nvm ls | grep 'node')
+b=${a#*(-> }
+v=${b%%[)| ]*}
+
+export PATH="$NVM_DIR/versions/node/$v/bin:$PATH"
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --type=bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+
+# If there are whitespace errors, print the offending file names and fail.
+git diff-index --check --cached $against --
+
+
+# check types
+npx tsc
+
+# check linting for all files that changes
+FILES_CHANGED=$(git diff-index --name-only --cached $against | grep -E ".+(tsx|jsx|ts|js)$")
+
+for FILE in $FILES_CHANGED
+do
+  if [ -f $FILE ]; then
+    npx eslint --max-warnings=0 $FILE
+  fi
+done

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,7 @@
         "full-icu": "^1.3.1",
         "html-webpack-plugin": "^5.5.0",
         "http-server": "^14.1.0",
+        "husky": "^8.0.1",
         "jest": "^27.5.1",
         "mini-css-extract-plugin": "^2.6.0",
         "msw": "^0.39.2",
@@ -12497,6 +12498,21 @@
       "dev": true,
       "engines": {
         "node": ">=8.12.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyphenate-style-name": {
@@ -33065,6 +33081,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true
+    },
+    "husky": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true
     },
     "hyphenate-style-name": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "compile": "(npm run compile:de; npm run compile:en; npm run compile:es) && npx prettier --write 'src/lang/**/*.json'",
     "compile:de": "formatjs compile src/lang/translations/de.json --ast --out-file src/lang/compiled/de.json",
     "compile:en": "formatjs compile src/lang/translations/en.json --ast --out-file src/lang/compiled/en.json",
-    "compile:es": "formatjs compile src/lang/translations/es.json --ast --out-file src/lang/compiled/es.json"
+    "compile:es": "formatjs compile src/lang/translations/es.json --ast --out-file src/lang/compiled/es.json",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@date-io/date-fns": "^1.3.13",
@@ -160,6 +161,7 @@
     "full-icu": "^1.3.1",
     "html-webpack-plugin": "^5.5.0",
     "http-server": "^14.1.0",
+    "husky": "^8.0.1",
     "jest": "^27.5.1",
     "mini-css-extract-plugin": "^2.6.0",
     "msw": "^0.39.2",


### PR DESCRIPTION
This PR introduces a pre-commit hook, which checks for the following:
 - linting on all files with changes (`npx eslint`)
 - type checks on the whole project  (`npx tsc`)
 - no non-ASCII characters in file names
 - whitespace errors, e.g. missing new line on EOF